### PR TITLE
Patch issue #5 - (login screen fatal crash on error dialog)

### DIFF
--- a/lib/screens/username/username_screen.dart
+++ b/lib/screens/username/username_screen.dart
@@ -24,6 +24,13 @@ class UsernameScreen extends StatelessWidget {
                 context: context,
                 builder: (context) => ErrorDialog(
                   content: state.failure.message,
+                  onPressed: () {
+                    context.read<UsernameCubit>().reset();
+                    context
+                        .read<UsernameCubit>()
+                        .usernameChanged(state.username);
+                    Navigator.of(context).pop();
+                  },
                 ),
               );
             }

--- a/lib/screens/username/username_screen.dart
+++ b/lib/screens/username/username_screen.dart
@@ -25,6 +25,8 @@ class UsernameScreen extends StatelessWidget {
                 builder: (context) => ErrorDialog(
                   content: state.failure.message,
                   onPressed: () {
+                    // Fix: Avoid double route stack pop in default function. In username_screen, only one route exists in the stack,
+                    // so this custom callback pops it once to prevent an empty stack error that would cause the app to crash.
                     context.read<UsernameCubit>().reset();
                     context
                         .read<UsernameCubit>()


### PR DESCRIPTION
This PR should patch issue #5 that fatally crashes the app when clicking 'ok' on the ErrorDialog from the username screen. It will now clear the dialog, and bring back the username input.