### PR TITLE
Fix #30 - Create new route for SmallTrackDetailScreen

### DIFF
--- a/lib/my_router.dart
+++ b/lib/my_router.dart
@@ -64,10 +64,18 @@ class MyRouter {
               return SignupScreen();
             },
           ),
+
           GoRoute(
             path: '/username',
             builder: (BuildContext context, GoRouterState state) {
               return UsernameScreen();
+            },
+          ),
+
+          GoRoute(
+            path: '/playerDetail',
+            builder: (BuildContext context, GoRouterState state) {
+              return PlayerSmallTrackDetailScreen();
             },
           ),
 

--- a/lib/my_router.dart
+++ b/lib/my_router.dart
@@ -71,7 +71,10 @@ class MyRouter {
               return UsernameScreen();
             },
           ),
-
+        // Pushing the SmallTrackDetailScreen to the rootNavigator was causing unexpected behavior when popping the navigation stack. 
+        // We first tried using shellNavigatorKey.currentState (from the ShellNavigator in goRouter), but it left the PlayerWithScaffold visible. 
+        // Instead, we created a new route outside of the ShellRoute/ShellNavigator to display the track detail screen in fullscreen, as before. 
+        // This change improves flexibility and performance by giving it its own dedicated route.
           GoRoute(
             path: '/playerDetail',
             builder: (BuildContext context, GoRouterState state) {

--- a/lib/screens/player/widgets/small_player.dart
+++ b/lib/screens/player/widgets/small_player.dart
@@ -1,5 +1,6 @@
 import 'package:boxify/app_core.dart';
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 
 class SmallPlayer extends StatelessWidget {
   const SmallPlayer({
@@ -33,13 +34,8 @@ class SmallPlayer extends StatelessWidget {
         children: [
           GestureDetector(
             // Define what happens when the widget is tapped
-            onTap: () => Navigator.of(context, rootNavigator: true).push(
-              MaterialPageRoute(
-                // The builder returns an instance of the PlayerSmallTrackDetailScreen
-                builder: (BuildContext context) =>
-                    PlayerSmallTrackDetailScreen(),
-              ),
-            ),
+            // Push the playerDetail screen to the navigation stack
+            onTap: () => GoRouter.of(context).push('/playerDetail'),
             child: Row(children: [
               /// IMAGE
               Padding(

--- a/lib/screens/player/widgets/small_player.dart
+++ b/lib/screens/player/widgets/small_player.dart
@@ -33,8 +33,6 @@ class SmallPlayer extends StatelessWidget {
         mainAxisAlignment: MainAxisAlignment.spaceBetween,
         children: [
           GestureDetector(
-            // Define what happens when the widget is tapped
-            // Push the playerDetail screen to the navigation stack
             onTap: () => GoRouter.of(context).push('/playerDetail'),
             child: Row(children: [
               /// IMAGE


### PR DESCRIPTION
This PR should fix issue #30.

Pushing the `SmallTrackDetailScreen` to the rootNavigator was causing unexpected behavior when popping the navigation stack. I first tried using `shellNavigatorKey.currentState` _(from the ShellNavigator in goRouter)_, but it left the `PlayerWithScaffold` visible. Instead, I created a new route outside of the ShellRoute/ShellNavigator to display the track detail screen in fullscreen, as before. This change improves flexibility and performance by giving it its own dedicated route.