### PR TITLE
Fix incorrect playlist name in SmallTrackDetailScreen

### DIFF
--- a/lib/screens/small_track_detail/small_track_detail_screen.dart
+++ b/lib/screens/small_track_detail/small_track_detail_screen.dart
@@ -54,7 +54,7 @@ class _PlayerSmallTrackDetailScreenState<Track>
               children: [
                 // const SizedBox(height: 20),
                 SmallDetailTopListTile(
-                  playlist: playlistBloc.state.viewedPlaylist,
+                  playlist: playlistBloc.state.enquedPlaylist,
                   track: track,
                   source: 'PLAYLIST',
                 ),


### PR DESCRIPTION
Related to issue #34 (apparently writing 'fix' will make github automatically close the issue when this PR is merged, so maybe writing 'related' won't).

The playlist name shown at the top of the SmallPlayerDetailScreen (below 'PLAYING FROM PLAYLIST') shows the last opened playlist instead of the enqueued one.

## Steps to reproduce
- Enqueue a playlist
- Open another playlist
- Open the detailed player screen: playlist name should be incorrect.

To fix this, I've changed the displayed state from `viewedPlaylist` to `enqueuedPlaylist` which should contain the correct playlist name.