### PR TITLE
handle PurchaseListener firebase exception

### DIFF
--- a/lib/services/purchase_listener_mixin.dart
+++ b/lib/services/purchase_listener_mixin.dart
@@ -64,6 +64,8 @@ mixin PurchaseListenerMixin<T extends StatefulWidget> on State<T> {
       } else {
         logger.f('No new purchases detected.');
       }
+    }, onError: (error) {
+      logger.e('Error listening to purchases: $error');
     });
   }
 }


### PR DESCRIPTION
This is a small PR that aims at handling potential PurchaseListener exceptions, to prevent uncaught exceptions from blocking the main thread.