### PR TITLE
Dynamically extract track's background color from its cover image

### DIFF
--- a/lib/helpers/color_helper.dart
+++ b/lib/helpers/color_helper.dart
@@ -1,0 +1,30 @@
+import 'package:flutter/material.dart';
+
+class ColorHelper {
+  /// Ensures that the provided color is not too dark or too light.
+  /// Returns the adjusted color if it is outside the specified range.
+  /// Parameters minLightness and maxLightness should be in the range 0.0 to 1.0.
+  static Color ensureWithinRange(
+    Color color, {
+    double minLightness = 0.2,
+    double maxLightness = 0.8,
+  }) {
+    final hslColor = HSLColor.fromColor(color);
+    double lightness = hslColor.lightness;
+    if (lightness < minLightness) {
+      return hslColor.withLightness(minLightness).toColor();
+    } else if (lightness > maxLightness) {
+      return hslColor.withLightness(maxLightness).toColor();
+    }
+    return color;
+  }
+
+  /// Returns a "dimmed" version of the provided color.
+  /// The dimFactor (between 0.0 and 1.0) indicates how much to reduce the
+  /// color's lightness.
+  static Color dimColor(Color color, {double dimFactor = 0.1}) {
+    final hslColor = HSLColor.fromColor(color);
+    final newLightness = (hslColor.lightness - dimFactor).clamp(0.0, 1.0);
+    return hslColor.withLightness(newLightness).toColor();
+  }
+}

--- a/lib/screens/lyrics/lyrics_screen.dart
+++ b/lib/screens/lyrics/lyrics_screen.dart
@@ -29,7 +29,11 @@ class LyricsScreen extends StatelessWidget {
           ],
         ),
         SliverToBoxAdapter(
-          child: LyricsWidget(track: track),
+          // TODO: We use track.backgroundColor because no image is directly available here,
+          // but we should extract this color from the image directly (like in small_track_detail_screen.dart)
+          // the value should probably be inherited from parents?
+          child: LyricsWidget(
+              track: track, backgroundColor: track.backgroundColor),
         ),
       ],
     );
@@ -37,9 +41,12 @@ class LyricsScreen extends StatelessWidget {
 }
 
 class LyricsWidget extends StatelessWidget {
-  const LyricsWidget({Key? key, required this.track}) : super(key: key);
+  const LyricsWidget(
+      {Key? key, required this.track, required this.backgroundColor})
+      : super(key: key);
 
   final Track track;
+  final Color backgroundColor;
 
   @override
   Widget build(BuildContext context) {
@@ -59,9 +66,7 @@ class LyricsWidget extends StatelessWidget {
     return Container(
       // give it rounded corners
       decoration: BoxDecoration(
-        borderRadius: BorderRadius.circular(10),
-        color: track.backgroundColor,
-      ),
+          borderRadius: BorderRadius.circular(10), color: backgroundColor),
 
       child: Padding(
         padding: padding,

--- a/lib/screens/player/widgets/small_player.dart
+++ b/lib/screens/player/widgets/small_player.dart
@@ -1,25 +1,37 @@
 import 'package:boxify/app_core.dart';
+import 'package:boxify/helpers/color_helper.dart';
+import 'package:boxify/ui/image_with_color_extraction.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 
-class SmallPlayer extends StatelessWidget {
+class SmallPlayer extends StatefulWidget {
   const SmallPlayer({
-    super.key,
+    Key? key,
     this.imageUrl,
     this.imageFilename,
     required this.track,
-  });
+  }) : super(key: key);
 
   final String? imageUrl;
   final String? imageFilename;
   final Track track;
 
   @override
+  State<SmallPlayer> createState() => _SmallPlayerState();
+}
+
+class _SmallPlayerState extends State<SmallPlayer> {
+  // Background color, extracted from the track's cover image
+  // use theme default color if not available
+  Color trackBackgroundColor =
+      ColorHelper.dimColor(Core.appColor.primary, dimFactor: 0.25);
+
+  @override
   Widget build(BuildContext context) {
     return Container(
       decoration: BoxDecoration(
         borderRadius: BorderRadius.circular(8),
-        color: track.backgroundColor,
+        color: trackBackgroundColor,
         boxShadow: const [
           BoxShadow(
             blurRadius: 2,
@@ -38,23 +50,31 @@ class SmallPlayer extends StatelessWidget {
               /// IMAGE
               Padding(
                 padding: const EdgeInsets.all(5),
-                child: ClipRRect(
-                  borderRadius: BorderRadius.circular(8),
-                  child: imageOrIcon(
-                    imageUrl: imageUrl,
-                    filename: imageFilename,
-                    height: Core.app.smallRowImageSize,
-                    width: Core.app.smallRowImageSize,
-                  ),
+                child: ImageWithColorExtraction(
+                  imageUrl: widget.imageUrl,
+                  filename: widget.imageFilename,
+                  height: Core.app.smallRowImageSize,
+                  width: Core.app.smallRowImageSize,
+                  roundedCorners: 8,
+                  onColorExtracted: (color) {
+                    setState(() {
+                      // Dim the color a bit to make the text more readable
+                      trackBackgroundColor = ColorHelper.dimColor(
+                          // Ensure the color isn't too dark to avoid interfering with the UI
+                          ColorHelper.ensureWithinRange(color,
+                              minLightness: 0.6, maxLightness: 1),
+                          dimFactor: 0.25);
+                    });
+                  },
                 ),
               ),
 
               /// TITLE AND ARTIST
               SmallPlayerTitleAndArtistWidget(
-                  track: track, isWide: !track.isRateable),
+                  track: widget.track, isWide: !widget.track.isRateable),
             ]),
           ),
-          StarRating(track: track),
+          StarRating(track: widget.track),
           PlayButton(
               // track: track,
               ),

--- a/lib/screens/player/widgets/small_player_title_and_artist_widget.dart
+++ b/lib/screens/player/widgets/small_player_title_and_artist_widget.dart
@@ -52,7 +52,7 @@ class SmallPlayerTitleAndArtistWidget extends StatelessWidget {
             child: TextOrMarquee(
               text: track.artist ?? '',
               style: TextStyle(
-                color: Colors.grey[500],
+                color: Colors.white.withAlpha(150),
                 fontSize: 13,
               ),
             ),

--- a/lib/screens/small_track_detail/small_track_detail_screen.dart
+++ b/lib/screens/small_track_detail/small_track_detail_screen.dart
@@ -77,6 +77,9 @@ class _PlayerSmallTrackDetailScreenState<Track>
                         width: width - 100,
                         roundedCorners: 8,
                         onColorExtracted: (color) {
+                          // Make sure widget is mounted before setting state
+                          // This may happen if the user closes the screen before the image is loaded
+                          if (!mounted) return;
                           setState(() {
                             // Update the current background color every time a new image is loaded
                             // Also ensure that the background isnt too light or too dark
@@ -86,7 +89,6 @@ class _PlayerSmallTrackDetailScreenState<Track>
                                 maxLightness: 0.7);
                           });
                         },
-                        // roundedCorners: 8,
                       ),
                       const SizedBox(height: 20),
                       SongInfoWidget(track: track),

--- a/lib/screens/small_track_detail/small_track_detail_screen.dart
+++ b/lib/screens/small_track_detail/small_track_detail_screen.dart
@@ -1,4 +1,5 @@
 import 'package:boxify/app_core.dart';
+import 'package:boxify/ui/image_with_color_extraction.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
@@ -14,6 +15,9 @@ class PlayerSmallTrackDetailScreen extends StatefulWidget {
 
 class _PlayerSmallTrackDetailScreenState<Track>
     extends State<PlayerSmallTrackDetailScreen> {
+  // Track backgroundColor, used for the gradient
+  Color _backgroundColor = Colors.grey;
+
   @override
   Widget build(BuildContext context) {
     return BlocBuilder<PlayerBloc, MyPlayerState>(
@@ -44,7 +48,7 @@ class _PlayerSmallTrackDetailScreenState<Track>
                 begin: Alignment.topCenter,
                 end: Alignment.bottomCenter,
                 colors: [
-                  track.backgroundColor,
+                  _backgroundColor,
                   Core.appColor.widgetBackgroundColor,
                 ],
               ),
@@ -65,12 +69,20 @@ class _PlayerSmallTrackDetailScreenState<Track>
                   padding: const EdgeInsets.only(left: 40, right: 40),
                   child: Column(
                     children: [
-                      imageOrIcon(
+                      ImageWithColorExtraction(
                         imageUrl: imageUrl,
                         filename: imageFilename,
+                        // filename: imageFilename,
                         height: width - 100, // Notice these are both from width
                         width: width - 100,
                         roundedCorners: 8,
+                        onColorExtracted: (color) {
+                          setState(() {
+                            // Update the current background color every time a new image is loaded
+                            _backgroundColor = color;
+                          });
+                        },
+                        // roundedCorners: 8,
                       ),
                       const SizedBox(height: 20),
                       SongInfoWidget(track: track),
@@ -81,7 +93,8 @@ class _PlayerSmallTrackDetailScreenState<Track>
                         track: track,
                       ),
                       const SizedBox(height: 10),
-                      LyricsWidget(track: track),
+                      LyricsWidget(
+                          track: track, backgroundColor: _backgroundColor),
                     ],
                   ),
                 ),

--- a/lib/screens/small_track_detail/small_track_detail_screen.dart
+++ b/lib/screens/small_track_detail/small_track_detail_screen.dart
@@ -1,4 +1,5 @@
 import 'package:boxify/app_core.dart';
+import 'package:boxify/helpers/color_helper.dart';
 import 'package:boxify/ui/image_with_color_extraction.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -72,14 +73,17 @@ class _PlayerSmallTrackDetailScreenState<Track>
                       ImageWithColorExtraction(
                         imageUrl: imageUrl,
                         filename: imageFilename,
-                        // filename: imageFilename,
                         height: width - 100, // Notice these are both from width
                         width: width - 100,
                         roundedCorners: 8,
                         onColorExtracted: (color) {
                           setState(() {
                             // Update the current background color every time a new image is loaded
-                            _backgroundColor = color;
+                            // Also ensure that the background isnt too light or too dark
+                            _backgroundColor = ColorHelper.ensureWithinRange(
+                                color,
+                                minLightness: 0.25,
+                                maxLightness: 0.7);
                           });
                         },
                         // roundedCorners: 8,

--- a/lib/ui/image_with_color_extraction.dart
+++ b/lib/ui/image_with_color_extraction.dart
@@ -110,7 +110,7 @@ class _ImageWithColorExtractionState extends State<ImageWithColorExtraction> {
       for (int x = 0; x < width; x += step) {
         // Sample pixel: get the color values and add them to the running totals.
         final pixel = image.getPixel(x, y);
-        r += pixel.r; // ref
+        r += pixel.r; // red
         g += pixel.g; // green
         b += pixel.b; // blue
         samples++;

--- a/lib/ui/image_with_color_extraction.dart
+++ b/lib/ui/image_with_color_extraction.dart
@@ -1,0 +1,171 @@
+import 'dart:math';
+import 'dart:ui' as ui;
+import 'dart:typed_data';
+
+import 'package:boxify/app_core.dart';
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:image/image.dart' as img;
+
+class ImageWithColorExtraction extends StatefulWidget {
+  final String? imageUrl;
+  final String? filename;
+  final String? placeholder;
+  final ValueChanged<Color> onColorExtracted;
+  final double height;
+  final double width;
+  final double? roundedCorners;
+
+  const ImageWithColorExtraction({
+    super.key,
+    this.imageUrl,
+    this.filename,
+    this.placeholder,
+    required this.onColorExtracted,
+    required this.height,
+    required this.width,
+    this.roundedCorners,
+  });
+
+  @override
+  State<ImageWithColorExtraction> createState() =>
+      _ImageWithColorExtractionState();
+}
+
+class _ImageWithColorExtractionState extends State<ImageWithColorExtraction> {
+  late ImageProvider? _imageProvider;
+
+  @override
+  void initState() {
+    super.initState();
+    _initImageProvider();
+
+    // If a valid provider is set, extract the average color.
+    if (_imageProvider != null) _extractAverageColor();
+  }
+
+  void _initImageProvider() {
+    // Set the image provider: network, cached, or asset image.
+    // If no image is provided, set it to null.
+    _imageProvider = widget.imageUrl != null
+        ? kIsWeb
+            ? NetworkImage(widget.imageUrl!) as ImageProvider
+            : CachedNetworkImageProvider(widget.imageUrl!)
+        : widget.filename != null
+            ? AssetImage(widget.filename!)
+            : null;
+  }
+
+  void _extractAverageColor() async {
+    if (_imageProvider == null) return;
+    try {
+      final ImageStream imageStream =
+          _imageProvider!.resolve(ImageConfiguration.empty);
+
+      // Wait for the image to load and extract the average color.
+      imageStream.addListener(
+        ImageStreamListener((ImageInfo info, bool synchronousCall) async {
+          // Image is loaded; convert it to a Uint8List (so we can read its data).
+          final ui.Image uiImage = info.image;
+          final ByteData? byteData =
+              await uiImage.toByteData(format: ui.ImageByteFormat.png);
+          if (byteData == null) return;
+
+          // Use the correct offset and length when converting ByteData to Uint8List.
+          // This is needed because the ByteData may contain extra data at the beginning.
+          final Uint8List imageBytes = byteData.buffer.asUint8List(
+            byteData.offsetInBytes,
+            byteData.lengthInBytes,
+          );
+
+          // Decode the image so we can use it to extract the average color.
+          final img.Image? decodedImage = img.decodeImage(imageBytes);
+          if (decodedImage == null) return;
+
+          final Color averageColor = _calculateAverageColor(decodedImage);
+          widget.onColorExtracted(averageColor);
+        }),
+      );
+    } catch (e) {
+      logger.e('Error extracting average color: $e');
+    }
+  }
+
+  Color _calculateAverageColor(img.Image image) {
+    final width = image.width;
+    final height = image.height;
+    final totalPixels = width * height;
+    const sampleSize = 100;
+
+    // Determine the step size for sampling the image.
+    // the step value = nbr of pixels to skip between samples
+    int step = sqrt(totalPixels / sampleSize).floor();
+    step = step.clamp(1, 100); // must be between 1 and 100
+
+    double r = 0, g = 0, b = 0;
+    int samples = 0;
+
+    for (int y = 0; y < height; y += step) {
+      for (int x = 0; x < width; x += step) {
+        // Sample pixel: get the color values and add them to the running totals.
+        final pixel = image.getPixel(x, y);
+        r += pixel.r; // ref
+        g += pixel.g; // green
+        b += pixel.b; // blue
+        samples++;
+      }
+    }
+
+    // Return the average of the sampled colors.
+    return Color.fromARGB(
+      255, // alpha channel (transparency). set it to 255 (opaque)
+      (r / samples).round(),
+      (g / samples).round(),
+      (b / samples).round(),
+    );
+  }
+
+  @override
+  void didUpdateWidget(covariant ImageWithColorExtraction oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    // Onlt re-extract the color if the image URL has changed.
+    if (widget.imageUrl != oldWidget.imageUrl) {
+      // Update the image provider and extract color for the new URL.
+      _initImageProvider();
+      _extractAverageColor();
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (widget.filename == null && widget.imageUrl == null) {
+      // Create a 'placeholder' box with a music note icon in its center
+      return Container(
+          height: widget.height,
+          width: widget.width,
+          decoration: BoxDecoration(
+            color: Core.appColor.widgetBackgroundColor,
+            borderRadius: BorderRadius.circular(widget.roundedCorners ?? 0),
+          ),
+          child: const Icon(Icons.music_note));
+    }
+
+    return ClipRRect(
+      borderRadius: BorderRadius.circular(widget.roundedCorners ?? 0),
+      child: _imageProvider != null
+          ? Image(
+              image: _imageProvider!,
+              height: widget.height,
+              width: widget.width,
+              fit: BoxFit.cover,
+            )
+          : Image.asset(
+              widget.placeholder ?? 'assets/images/placeholder.png',
+              height: widget.height,
+              width: widget.width,
+              fit: BoxFit.cover,
+            ),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -40,6 +40,7 @@ dependencies:
   bloc_concurrency: ^0.2.2
   charcode: ^1.2.0
   cached_network_image: ^3.3.1
+  image: ^4.0.15
   connectivity_plus: ^5.0.2
   clipboard: ^0.1.3     
   device_info_plus: ^9.0.3
@@ -98,7 +99,7 @@ dependency_overrides:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_launcher_icons: ^0.10.0
+  flutter_launcher_icons: ^0.13.1
   dependency_validator: ^3.1.2
   mockito: ^5.4.4
   test: ^1.16.8


### PR DESCRIPTION
This PR replaces the background colors visible in the SmallPlayer, SmallTrackDetailedScreen and LyricsScreen with the average color of the current track's cover image. Some color corrections are also applied to ensure that the extracted colors don't interfere with the UI.

**Some screenshots:**
![image](https://github.com/user-attachments/assets/d27b3c00-967d-4f38-ba8c-ff8cb5736cd4)
![image](https://github.com/user-attachments/assets/1776fb29-80df-4404-865b-a1c693cc1d18)

![image](https://github.com/user-attachments/assets/f13823a7-fab2-443b-be51-3d52ff8c1cbb)

**Other changes:**
- Created a new placeholder for tracks with no `imageURL` or `filename`. It should now look like this: 
![image](https://github.com/user-attachments/assets/eb916035-120f-4e1e-aab6-e17d05054ac9)
- There was a version mismatch between Boxify and Examplify for the `flutter_launcher_icons` package, which prevented me from using the `Image` package. I've upgraded them to version `0.13.1`.

**Details:**
I initially thought about using the 'palette_generator' package, as described in #40. But this package has just been marked as deprecated by the flutter teams, and it seemed to do a lot more operations than necessary. So instead, I've used a simple pixel sampling method that should run at a constant cost of operations.

In order to extract the color from the image without having to load it twice, I've created the ImageWithColorExtraction widget (using the ImageOrIcon widget that was previously used in the player) and added a listener on the image stream to directly access the image data.

The color is extracted using a callback from the ImageWithColorExtraction widget, so the parent can access the value. Because of this, I had to turn the stateless SmallPlayer widget into a stateful widget in order for the color to be stored in a dynamic state and update accordingly.

To prevent these colors from interfering with the UI (like the white and black text for example), I've created a ColorHelper to adjust and correct colors that could be incompatible with the UI. Here's an example:

| Without any color correction  |  With color correction |
|---|---|
|  ![image](https://github.com/user-attachments/assets/aca8dfd7-3606-4958-97cd-810cd4a58c70) |  ![image](https://github.com/user-attachments/assets/3ea5e977-9fd0-4569-94ae-1746b3040129) |

If it's all good, I could also add this feature to playlists. I also haven't added the new placeholder in the ImageOrIcon widget, I could also do this later if you think that would be a good idea. 