### PR TITLE
fix for image cutoff in bundles, badges, playlists on large screen

### DIFF
--- a/lib/screens/artist/artist_screen.dart
+++ b/lib/screens/artist/artist_screen.dart
@@ -658,6 +658,7 @@ class _ArtistScreenState extends State<ArtistScreen>
         final fontSize = isLargeScreen ? 80.0 : 50.0;
         final artistState = context.read<ArtistBloc>().state;
         final sectionPadding = EdgeInsets.all(14.0);
+        final crossAxisCount = screenWidth ~/ 250;
 
         return
             // Give the custom scroll view a non-scrolling background
@@ -752,7 +753,7 @@ class _ArtistScreenState extends State<ArtistScreen>
                             isLargeScreen
                                 ? BundlesForLargeArtist(
                                     sectionHeight: getLargeSectionHeight(
-                                        state.bundles.length),
+                                        state.bundles.length, crossAxisCount),
                                     bundles: state.bundles,
                                     openBundlePreview: _openBundlePreview,
                                   )
@@ -789,7 +790,7 @@ class _ArtistScreenState extends State<ArtistScreen>
                             isLargeScreen
                                 ? BadgesForLargeArtist(
                                     sectionHeight: getLargeSectionHeight(
-                                        state.badges.length),
+                                        state.badges.length, crossAxisCount),
                                     badges: state.badges,
                                     openBadgePreview: _openBadgePreview,
                                   )
@@ -842,7 +843,8 @@ class _ArtistScreenState extends State<ArtistScreen>
                             isLargeScreen
                                 ? PlaylistsForLargeArtist(
                                     sectionHeight: getLargeSectionHeight(
-                                        state.userPlaylists.length),
+                                        state.userPlaylists.length, crossAxisCount),
+                                        
                                     playlists: userPlaylists,
                                   )
                                 : SmallMediaSection(

--- a/lib/screens/artist/helpers.dart
+++ b/lib/screens/artist/helpers.dart
@@ -16,8 +16,11 @@ double getVerySmallSectionHeight(int items) {
 }
 
 /// returns whichever is greater: 1 or the number of items divided by 4
-double getLargeSectionHeight(int items) {
+double getLargeSectionHeight(int items, int crossAxisCount) {
   const rowHeight = 350.0;
-  // basically, 8 items per row
-  return max(rowHeight, rowHeight * (items / 8).ceil().toDouble());
+
+  // dynamically calculates how many items fit in a row based on screen size
+  int rows = (items / crossAxisCount).ceil();
+  
+  return max(rowHeight, rowHeight * rows.toDouble());
 }


### PR DESCRIPTION
## Steps to reproduce

The bottom row on bundles, badges, and playlists in the profile screen on large screen devices (desktop, laptop, tablet) were occasionally being cut off.  This is because getLargeSectionHeight was relying on a set number of items per row.  If the screen width allowed less items than the set number, it would wrap the next item(s) without creating the needed row.  It is now set to dynamically calculate how many items can fit based on the screen width of the device, which can vary quite a bit on large screens.

When you navigate to the profile screen, you should be able to see all available bundles, badges, and playlists on an account.

