### PR TITLE
fix purple snackBarAction

### DIFF
--- a/lib/theme/boxify_theme.dart
+++ b/lib/theme/boxify_theme.dart
@@ -32,6 +32,9 @@ class BoxifyTheme {
       appBarTheme: AppBarTheme(
         iconTheme: IconThemeData(color: Core.appColor.text),
       ),
+      snackBarTheme: SnackBarThemeData(
+        actionTextColor: Core.appColor.text,
+      ),
     );
   }
 }


### PR DESCRIPTION
## Steps to reproduce

 If you click on a track you do not own the snackBar pops up with the option to 'Go to Market'. It was still showing purple but this pr fixes that and sets it to the app text color.