### PR TITLE
Using autofillHints in the TextFormField on the login_screen

### DIFF
--- a/lib/screens/login/login_screen.dart
+++ b/lib/screens/login/login_screen.dart
@@ -231,6 +231,8 @@ class LoginScreen extends StatelessWidget {
           final trimmedValue = value?.trim() ?? '';
           return !trimmedValue.contains('@') ? 'emailError'.translate() : null;
         },
+        autofillHints: const [AutofillHints.email],
+        keyboardType: TextInputType.emailAddress,
       ),
       sizedBox16,
       TextFormField(
@@ -239,6 +241,8 @@ class LoginScreen extends StatelessWidget {
         onChanged: (value) => context.read<LoginCubit>().passwordChanged(value),
         validator: (value) =>
             value!.length < 6 ? 'passwordError'.translate() : null,
+        autofillHints: const [AutofillHints.password],
+        keyboardType: TextInputType.visiblePassword,
       ),
       _buildTogglePasswordButton(context, state),
       sizedBox28,


### PR DESCRIPTION
Using autofillHints in the TextFormField on the login_screen to inform the browser to treat the field as an email.  

Also added keyboardType as .emailAddress to aid entry into the field.

Also included the changes for the password field but I was not able to test this successfully - maybe because there is not currently a saved password in my browser.

Current behaviour:

- Launch Boxify
- Click in "Email" field on login page
- No email recommendations are shown

Behaviour following change:

- Launch Boxify
- Click in "Email" field on login page
- Recommended email address shown by browser