### PR TITLE
home screen instead of library

### DIFF
--- a/lib/cubits/nav_cubit/nav_cubit.dart
+++ b/lib/cubits/nav_cubit/nav_cubit.dart
@@ -3,8 +3,10 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:boxify/app_core.dart';
 
 class NavCubit extends Cubit<int> {
-  NavCubit(int initialIndex)
-      : super(initialIndex); // Initial index as parameter
+  //NavCubit(int initialIndex) 
+  //  : super(initialIndex); // Initial index if want to set advanced and basic differently 
+  
+  NavCubit() : super(0); // Initial index set to 0 (home) for all app types
 
   void updateIndex(int newIndex) {
     emit(newIndex); // This updates the current state of the navigation index

--- a/lib/my_app.dart
+++ b/lib/my_app.dart
@@ -97,12 +97,12 @@ class MyApp extends StatelessWidget {
         ),
       ),
       BlocProvider<NavCubit>(
-        // create: (context) => NavCubit(),
-        create: (_) => NavCubit(
-          Core.app.type == AppType.advanced
-              ? bottomNavigationBarItemAdvanced(context).length - 1
-              : bottomNavigationBarItemBasic(context).length - 1,
-        ),
+        //create: (_) => NavCubit( 
+          //Core.app.type == AppType.advanced
+              //? bottomNavigationBarItemAdvanced(context).length - 1
+              //: bottomNavigationBarItemBasic(context).length - 1,
+        //),
+        create: (context) => NavCubit(), // applies to all app types
         child: MyApp(), // Your main app widget
       ),
       BlocProvider<PlaylistTracksBloc>(


### PR DESCRIPTION
## Steps to reproduce

The initial index was set to library in the `NavCubit` and `my app`.  I changed it to 0 index (home) for all app types.  

However, I did not delete the original code, I just commented it out.  That way it can be easily switched to that method if it is decided the different app types should each have a different initial index.

When you open the app on small screen now - it should show the home screen with home highlighted on the bottom.