### PR TITLE
ensure library page is loaded after login

### DIFF
--- a/lib/screens/login/login_screen.dart
+++ b/lib/screens/login/login_screen.dart
@@ -105,7 +105,7 @@ class LoginScreen extends StatelessWidget {
       logger.i(
           'authUser pressed Maybe Later  and authUser.isAnonymouse so naving to home screen');
       context.read<LoginCubit>().reset();
-      GoRouter.of(context).go('/');
+      GoRouter.of(context).go('/library');
     }
 
     /// USER PRESSED 'LOG IN'
@@ -163,7 +163,7 @@ class LoginScreen extends StatelessWidget {
 
         /// They didnt enter anything into the URL bar
         else {
-          GoRouter.of(context).go('/');
+          GoRouter.of(context).go('/library');
           // context.read<LoginCubit>().reset();
         }
       }

--- a/lib/screens/username/username_screen.dart
+++ b/lib/screens/username/username_screen.dart
@@ -43,7 +43,7 @@ class UsernameScreen extends StatelessWidget {
               if (state.usernameIsValid) {
                 logger
                     .i('UsernameStatus.initial but already valid so nav time');
-                GoRouter.of(context).push('/');
+                GoRouter.of(context).push('/library');
               }
             }
             if (state.status == UsernameStatus.success) {
@@ -67,7 +67,7 @@ class UsernameScreen extends StatelessWidget {
                     viewer: context.read<UserBloc>().state.user));
 
                 /// TODO: IS NOT LOADED YET
-                GoRouter.of(context).go('/');
+                GoRouter.of(context).go('/library');
               }
             }
           },


### PR DESCRIPTION
## Steps to reproduce

App was opening after login or initially setting username to home page.  Thereafter it would load to library (as intended).  

This is because `username screen` and `login screen` were routing users to home instead of library. And after that the router was sending users to the appropriate screen.

Now it should open to library consistently as intended.

I did not know how to work off the previous branch that was committed but not merged so I created one off my forked repo.