### PR TITLE
Lazy-load tracks

### DIFF
--- a/examplify/pubspec.yaml
+++ b/examplify/pubspec.yaml
@@ -30,6 +30,7 @@ dependencies:
   #     ref: main  # or any branch/tag
 
   material_design_icons_flutter: 7.0.7296
+  shimmer: ^3.0.0
  
 dev_dependencies:
 

--- a/lib/base_app.dart
+++ b/lib/base_app.dart
@@ -432,6 +432,10 @@ class BaseColor {
   Color subtitleColor = const Color.fromARGB(255, 158, 158, 158);
   Color titleColor = Color.fromARGB(255, 255, 255, 255);
   Color discordColor = Color.fromARGB(255, 114, 137, 218);
+
+  // Skeletons & Shimmer effects
+  Color shimmerBaseColor = Colors.grey[300]!.withOpacity(0.3);
+  Color shimmerHighlightColor = Colors.grey[300]!.withOpacity(0.45);
 }
 
 class BaseUI {

--- a/lib/blocs/playlist/playlist_bloc.dart
+++ b/lib/blocs/playlist/playlist_bloc.dart
@@ -384,6 +384,8 @@ class PlaylistBloc extends Bloc<PlaylistEvent, PlaylistState> {
     }
     emit(
       state.copyWith(
+        // Set viewed playlist before it has loaded so that the UI can show playlist info while it loads
+        viewedPlaylist: event.playlist,
         status: PlaylistStatus.viewedPlaylistLoading,
       ),
     );
@@ -394,11 +396,8 @@ class PlaylistBloc extends Bloc<PlaylistEvent, PlaylistState> {
             (trackState) => trackState.tracksLoadStatus == LoadStatus.loaded);
       }
 
-      emit(
-        state.copyWith(
-            viewedPlaylist: event.playlist,
-            status: PlaylistStatus.viewedPlaylistLoaded),
-      );
+      // Signal that the playlist has been loaded
+      emit(state.copyWith(status: PlaylistStatus.viewedPlaylistLoaded));
     } catch (err, s) {
       logger.e('error in _selectPlaylist: $err\n$s');
       emit(

--- a/lib/blocs/playlist/playlist_bloc.dart
+++ b/lib/blocs/playlist/playlist_bloc.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:boxify/app_core.dart';
+import 'package:boxify/enums/load_status.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:equatable/equatable.dart';
 // ignore: depend_on_referenced_packages
@@ -11,6 +12,7 @@ part 'playlist_state.dart';
 
 class PlaylistBloc extends Bloc<PlaylistEvent, PlaylistState> {
   final AuthBloc _authBloc;
+  final TrackBloc _trackBloc;
 
   final PlaylistRepository _playlistRepository;
   final UserRepository _userRepository;
@@ -19,6 +21,7 @@ class PlaylistBloc extends Bloc<PlaylistEvent, PlaylistState> {
 
   PlaylistBloc({
     required AuthBloc authBloc,
+    required TrackBloc trackBloc,
     required UserRepository userRepository,
     required TrackRepository trackRepository,
     required PlaylistRepository playlistRepository,
@@ -26,6 +29,7 @@ class PlaylistBloc extends Bloc<PlaylistEvent, PlaylistState> {
     required StorageRepository storageRepository,
     required BundleRepository bundleRepository,
   })  : _authBloc = authBloc,
+        _trackBloc = trackBloc,
         _playlistRepository = playlistRepository,
         _userRepository = userRepository,
         _playlistHelper = PlaylistHelper(),
@@ -384,6 +388,12 @@ class PlaylistBloc extends Bloc<PlaylistEvent, PlaylistState> {
       ),
     );
     try {
+      // If tracks have not been loaded, wait for them to be loaded and ready
+      if (_trackBloc.state.tracksLoadStatus != LoadStatus.loaded) {
+        await _trackBloc.stream.firstWhere(
+            (trackState) => trackState.tracksLoadStatus == LoadStatus.loaded);
+      }
+
       emit(
         state.copyWith(
             viewedPlaylist: event.playlist,

--- a/lib/blocs/search/search_event.dart
+++ b/lib/blocs/search/search_event.dart
@@ -22,6 +22,12 @@ class ChangeQuery extends SearchEvent {
   List<Object?> get props => [query];
 }
 
+class ExecutePendingSearch extends SearchEvent {
+  const ExecutePendingSearch();
+  @override
+  List<Object?> get props => [];
+}
+
 class ClearSearch extends SearchEvent {
   const ClearSearch();
   @override

--- a/lib/blocs/search/search_state.dart
+++ b/lib/blocs/search/search_state.dart
@@ -13,9 +13,10 @@ class SearchState extends Equatable {
   final Failure failure;
   int searchTypeIndex; // Player Search: 0 for tracks, 1 for playlists, 2 for artists
   List<Track> searchResultsTracks; // or List<Track>?
-  String query;
   List<Playlist> searchResultsPlaylists;
   List<User> searchResultsUsers;
+  String query;
+  String pendingQuery; // Pending query (while tracks are loading)
 
   SearchState({
     required this.status,
@@ -25,6 +26,7 @@ class SearchState extends Equatable {
     required this.searchResultsPlaylists,
     required this.searchResultsUsers,
     this.query = '',
+    this.pendingQuery = '',
   });
 
   factory SearchState.initial() {
@@ -36,6 +38,7 @@ class SearchState extends Equatable {
       searchResultsPlaylists: const [],
       searchResultsUsers: const [],
       query: '',
+      pendingQuery: 'EMPTY',
     );
   }
 
@@ -47,7 +50,8 @@ class SearchState extends Equatable {
         searchResultsTracks,
         searchResultsPlaylists,
         searchResultsUsers,
-        query
+        query,
+        pendingQuery
       ];
 
   SearchState copyWith({
@@ -58,6 +62,7 @@ class SearchState extends Equatable {
     List<Playlist>? searchResultsPlaylists,
     List<User>? searchResultsUsers,
     String? query,
+    String? pendingQuery,
   }) {
     return SearchState(
       status: status ?? this.status,
@@ -68,6 +73,7 @@ class SearchState extends Equatable {
           searchResultsPlaylists ?? this.searchResultsPlaylists,
       searchResultsUsers: searchResultsUsers ?? this.searchResultsUsers,
       query: query ?? this.query,
+      pendingQuery: pendingQuery ?? this.pendingQuery,
     );
   }
 

--- a/lib/blocs/track/track_bloc.dart
+++ b/lib/blocs/track/track_bloc.dart
@@ -114,10 +114,8 @@ class TrackBloc extends Bloc<TrackEvent, TrackState> {
     final start2 = DateTime.now();
 
     // check for cached tracks first
-    // REMOVED FOR TESTS: MUST NOT FORGET TO PUT BACK!
-    //final cachedTracks = await _cacheHelper.getTracks(
-    //    event.serverUpdated, _authBloc.state.user!.uid);
-    final cachedTracks = <Track>[];
+    final cachedTracks = await _cacheHelper.getTracks(
+        event.serverUpdated, _authBloc.state.user!.uid);
 
     logRunTime(start2, 'cacheHelper.getTracks');
 

--- a/lib/blocs/track/track_bloc.dart
+++ b/lib/blocs/track/track_bloc.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:math';
 import 'package:bloc/bloc.dart';
 
 import 'package:boxify/app_core.dart';
@@ -9,8 +8,6 @@ import 'package:dio/dio.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:just_audio/just_audio.dart';
 import 'package:equatable/equatable.dart';
-
-import 'package:cloud_firestore/cloud_firestore.dart';
 
 part 'track_event.dart';
 part 'track_state.dart';

--- a/lib/blocs/track/track_state.dart
+++ b/lib/blocs/track/track_state.dart
@@ -21,6 +21,8 @@ class TrackState extends Equatable {
   bool clearCache;
   // final String? trackIdPassedToUrl;
   final String? mouseClickedTrackId;
+  // Have all the tracks been loaded from the server?
+  final LoadStatus tracksLoadStatus;
 
   TrackState({
     required this.displayedTracks,
@@ -31,6 +33,7 @@ class TrackState extends Equatable {
     required this.clearCache,
     // this.trackIdPassedToUrl,
     this.mouseClickedTrackId,
+    this.tracksLoadStatus = LoadStatus.notLoaded,
   });
 
   factory TrackState.initial() {
@@ -59,11 +62,13 @@ class TrackState extends Equatable {
         failure,
         // trackIdPassedToUrl,
         mouseClickedTrackId,
+        tracksLoadStatus,
       ];
 
   TrackState copyWith({
     List<Track>? displayedTracks,
     List<Track>? displayedTracksPlayable,
+    // Plan is to slowly replace #status with #tracksLoadStatus, as it supports asynchroneous loading
     TrackStatus? status,
     Failure? failure,
     List<Track>? allTracks,
@@ -71,6 +76,7 @@ class TrackState extends Equatable {
     Track? currentTrack,
     // String? trackIdPassedToUrl,
     String? mouseClickedTrackId,
+    LoadStatus? tracksLoadStatus,
   }) {
     return TrackState(
       displayedTracks: displayedTracks ?? this.displayedTracks,
@@ -82,6 +88,7 @@ class TrackState extends Equatable {
       clearCache: clearCache ?? this.clearCache,
       // trackIdPassedToUrl: trackIdPassedToUrl ?? this.trackIdPassedToUrl,
       mouseClickedTrackId: mouseClickedTrackId ?? this.mouseClickedTrackId,
+      tracksLoadStatus: tracksLoadStatus ?? this.tracksLoadStatus,
     );
   }
 }

--- a/lib/enums/load_status.dart
+++ b/lib/enums/load_status.dart
@@ -1,0 +1,15 @@
+// Tracks the status of an asynchronous/lazy load operation.
+// Used to signal whether a ressource (tracks, ratings, etc.) is available or not.
+enum LoadStatus {
+  /// The ressource is not available.
+  notLoaded,
+
+  /// The ressource is currently being loaded.
+  loading,
+
+  /// The ressource is available.
+  loaded,
+
+  /// Unable to load the ressource.
+  error
+}

--- a/lib/helpers/playlist_helper.dart
+++ b/lib/helpers/playlist_helper.dart
@@ -372,9 +372,9 @@ class PlaylistHelper {
   ) {
     logger.i('createNewReleasesPlaylist');
     try {
-    final newReleasesPlaylist = allPlaylists.firstWhere(
-        (element) => element.id == Core.app.newReleasesPlaylistId);
-    
+      final newReleasesPlaylist = allPlaylists.firstWhere(
+          (element) => element.id == Core.app.newReleasesPlaylistId);
+
       return newReleasesPlaylist;
     } catch (e) {
       logger.e('createNewReleasesPlaylist() error: $e');
@@ -508,6 +508,12 @@ class PlaylistHelper {
     if (kIsWeb) {
       return false;
     }
+
+    // If the playlist is empty, it can't be downloaded
+    if (tracks.isEmpty) {
+      return false;
+    }
+
     for (var track in tracks) {
       if (track.available == false) {
         return false;

--- a/lib/my_app.dart
+++ b/lib/my_app.dart
@@ -192,6 +192,7 @@ class MyApp extends StatelessWidget {
           trackRepository: context.read<TrackRepository>(),
           metaDataRepository: context.read<MetaDataRepository>(),
           bundleRepository: context.read<BundleRepository>(),
+          trackBloc: context.read<TrackBloc>(),
         ),
       ),
       Provider<PlaylistService>(

--- a/lib/my_app.dart
+++ b/lib/my_app.dart
@@ -1,4 +1,5 @@
 import 'package:boxify/app_core.dart';
+import 'package:boxify/enums/load_status.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -138,9 +139,19 @@ class MyApp extends StatelessWidget {
           audioPlayer: audioPlayer,
         ),
       ),
+      BlocProvider<TrackBloc>(
+        create: (context) => TrackBloc(
+          authBloc: context.read<AuthBloc>(),
+          userRepository: context.read<UserRepository>(),
+          trackRepository: context.read<TrackRepository>(),
+          storageRepository: context.read<StorageRepository>(),
+          metaDataRepository: context.read<MetaDataRepository>(),
+        ),
+      ),
       BlocProvider<PlaylistBloc>(
         create: (context) => PlaylistBloc(
           authBloc: context.read<AuthBloc>(),
+          trackBloc: context.read<TrackBloc>(),
           userRepository: context.read<UserRepository>(),
           trackRepository: context.read<TrackRepository>(),
           playlistRepository: context.read<PlaylistRepository>(),
@@ -181,15 +192,6 @@ class MyApp extends StatelessWidget {
           trackRepository: context.read<TrackRepository>(),
           metaDataRepository: context.read<MetaDataRepository>(),
           bundleRepository: context.read<BundleRepository>(),
-        ),
-      ),
-      BlocProvider<TrackBloc>(
-        create: (context) => TrackBloc(
-          authBloc: context.read<AuthBloc>(),
-          userRepository: context.read<UserRepository>(),
-          trackRepository: context.read<TrackRepository>(),
-          storageRepository: context.read<StorageRepository>(),
-          metaDataRepository: context.read<MetaDataRepository>(),
         ),
       ),
       Provider<PlaylistService>(
@@ -559,10 +561,10 @@ class MyApp extends StatelessWidget {
         listener: (context, state) {
           // logger.i('TrackBloc listener called with ${state.status}');
           final downloadBloc = context.read<DownloadBloc>();
-          final playerBloc = context.read<PlayerBloc>();
           // final playlistBloc = context.read<PlaylistBloc>();
           final trackBloc = context.read<TrackBloc>();
           final userBloc = context.read<UserBloc>();
+          final playerBloc = context.read<PlayerBloc>();
           final user = userBloc.state.user;
 
           /// Problem is the user is not yet loaded with the ratings. So we need to wait for the user to be loaded before we can map the ratings to the tracks.
@@ -589,40 +591,20 @@ class MyApp extends StatelessWidget {
               );
               // }
             }
-          } else if ((state.status == TrackStatus.ratingsMapped &&
-                  userBloc.state.status != UserStatus.updatedRating)
-              // &&
-
-              // /// If the user is loading a playlist from the url, then do not proceed
-              // playlistBloc.state.playlistIdPassedToUrl == null
-              ) {
-            final playlistBloc = context.read<PlaylistBloc>();
-            if (playlistBloc.state.status == PlaylistStatus.initial) {
-              final metaDataLoaded =
-                  context.read<MetaDataCubit>().state as MetaDataLoaded;
-
-              logger.i('loadAllPlaylists!');
-              playlistBloc.add(LoadAllPlaylists(
-                userId: user.id,
-                serverPlaylistsUpdated:
-                    metaDataLoaded.serverTimestamps['playlists'],
-              ));
-            }
-
-            // if (Core.app.type == AppType.basic) {
-            //   final tracks = trackBloc.state.allTracks;
-            //   final ratings = userBloc.state.ratings;
-            //   playlistBloc.add(
-            //     LoadUnratedPlaylist(
-            //         user: user, ratings: ratings, tracks: tracks),
-            //   );
-            // }
-            logger.d('playlistBloc.state.status: ${playlistBloc.state.status}');
-
+          } else if (state.tracksLoadStatus == LoadStatus.loaded &&
+              playerBloc.state.status == PlayerStatus.initial) {
+            // Once tracks are loaded, initialize the player with the initial track
             final track = getInitialTrack(trackBloc, user);
             logger.i('SetDisplayedTracksWithTracks');
+
             if (track != null) {
-              trackBloc.add(SetDisplayedTracksWithTracks(tracks: [track]));
+              // Only set the displayed tracks if no playlist is being viewed
+              // This may happen if the user clicked on a playlist while tracks were being loaded
+              final playlistBloc = context.read<PlaylistBloc>();
+              if (playlistBloc.state.viewedPlaylist == null) {
+                trackBloc.add(SetDisplayedTracksWithTracks(tracks: [track]));
+              }
+
               logger.i('LoadPlayer!');
               playerBloc.add(
                 LoadPlayer([track]),
@@ -642,6 +624,7 @@ class MyApp extends StatelessWidget {
           final metaDataCubit = context.read<MetaDataCubit>();
           final playlistBloc = context.read<PlaylistBloc>();
           final settingsBloc = context.read<SettingsBloc>();
+          final trackBloc = context.read<TrackBloc>();
           final userBloc = context.read<UserBloc>();
           final user = userBloc.state.user;
 
@@ -651,42 +634,37 @@ class MyApp extends StatelessWidget {
             ); // moved this up out of the block below
 
             // Load all tracks asynchonously after the user is loaded.
-            // This prevents the user from having to wait for the tracks to load
+            // This prevents the user from having to wait for the tracks to load before accessing the UI
             Future.microtask(() {
-              final trackBloc = context.read<TrackBloc>();
-              final serverUpdated = (metaDataCubit.state as MetaDataLoaded)
-                  .serverTimestamps['tracks']!;
-              trackBloc.add(
-                LoadAllTracks(
-                  serverUpdated: serverUpdated,
-                  clearCache:
-                      (marketBloc.state.status == MarketStatus.bundlePurchased),
-                  user: user,
-                ),
-              );
+              // wait 30 seconds for TEST (must be removed)
+              Future.delayed(const Duration(seconds: 30), () {
+                final serverUpdated = (metaDataCubit.state as MetaDataLoaded)
+                    .serverTimestamps['tracks']!;
+                trackBloc.add(
+                  LoadAllTracks(
+                    serverUpdated: serverUpdated,
+                    clearCache: (marketBloc.state.status ==
+                        MarketStatus.bundlePurchased),
+                    user: user,
+                  ),
+                );
+              });
             });
 
-            // if (trackBloc.state.status == TrackStatus.allTracksLoaded) {
-            //   logger.i('MapRatingsToTracks!');
+            // Load all playlists synchronously (for now, asynchonously later - TODO)
+            if (playlistBloc.state.status == PlaylistStatus.initial) {
+              final metaDataLoaded =
+                  context.read<MetaDataCubit>().state as MetaDataLoaded;
 
-            //   final ratings = userBloc.state.ratings;
+              logger.i('loadAllPlaylists!');
+              playlistBloc.add(LoadAllPlaylists(
+                userId: user.id,
+                serverPlaylistsUpdated:
+                    metaDataLoaded.serverTimestamps['playlists'],
+              ));
+            }
 
-            //   /// So yes, this in here twice, because there are 2 possible flows:
-            //   /// 1. The user is loaded after the tracks
-            //   /// 2. The tracks are loaded after the user
-            //   trackBloc.add(
-            //     MapRatingsToTracks(trackBloc.state.allTracks, ratings),
-            //   );
-            // }
-            // if (playlistBloc.state.status == PlaylistStatus.initial) {
-            //   final metaDataLoaded = metaDataCubit.state as MetaDataLoaded;
-            //   logger.i('loadAllPlaylists!');
-            //   playlistBloc.add(LoadAllPlaylists(
-            //     userId: user.id,
-            //     serverPlaylistsUpdated:
-            //         metaDataLoaded.serverTimestamps['playlists'],
-            //   ));
-            // }
+            // Load market
             if (Core.app.type == AppType.advanced) {
               // logger.i('loadMarket!');
               final marketBloc = context.read<MarketBloc>();

--- a/lib/my_app.dart
+++ b/lib/my_app.dart
@@ -637,19 +637,16 @@ class MyApp extends StatelessWidget {
             // Load all tracks asynchonously after the user is loaded.
             // This prevents the user from having to wait for the tracks to load before accessing the UI
             Future.microtask(() {
-              // wait 30 seconds for TEST (must be removed)
-              Future.delayed(const Duration(seconds: 30), () {
-                final serverUpdated = (metaDataCubit.state as MetaDataLoaded)
-                    .serverTimestamps['tracks']!;
-                trackBloc.add(
-                  LoadAllTracks(
-                    serverUpdated: serverUpdated,
-                    clearCache: (marketBloc.state.status ==
-                        MarketStatus.bundlePurchased),
-                    user: user,
-                  ),
-                );
-              });
+              final serverUpdated = (metaDataCubit.state as MetaDataLoaded)
+                  .serverTimestamps['tracks']!;
+              trackBloc.add(
+                LoadAllTracks(
+                  serverUpdated: serverUpdated,
+                  clearCache:
+                      (marketBloc.state.status == MarketStatus.bundlePurchased),
+                  user: user,
+                ),
+              );
             });
 
             // Load all playlists synchronously (for now, asynchonously later - TODO)

--- a/lib/screens/artist/artist_screen.dart
+++ b/lib/screens/artist/artist_screen.dart
@@ -63,9 +63,10 @@ class _ArtistScreenState extends State<ArtistScreen>
       logger.e('Error playing audio: $e');
     }
   }
-  // All the dialogs in the artist profile were being pushed to the root navigator, 
-  // that has a lower priority than the nested navigators used in the app and by the router. 
-  // Because of that, the dialog was popped only when the other navigators with higher priority 
+
+  // All the dialogs in the artist profile were being pushed to the root navigator,
+  // that has a lower priority than the nested navigators used in the app and by the router.
+  // Because of that, the dialog was popped only when the other navigators with higher priority
   // had an empty stack, leading to issue #21
   void _openBundlePreview(Bundle bundle) {
     final songList = bundle.songList?.split(',');

--- a/lib/screens/player/player.dart
+++ b/lib/screens/player/player.dart
@@ -1,4 +1,5 @@
 import 'package:boxify/app_core.dart';
+import 'package:boxify/screens/player/widgets/small_player_skeleton.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
@@ -25,7 +26,7 @@ class Player extends StatelessWidget {
           ) {
         logger.i(
             'Player - PlayerStatus == ${state.status} so returning CircularProgressIndicator()');
-        return circularProgressIndicator;
+        return SmallPlayerSkeleton();
       } else {
         /// Get the [Track] from the player.audiosource that is currently playing,
         /// or the first track in the PlayerState.queue if no track is playing

--- a/lib/screens/player/player.dart
+++ b/lib/screens/player/player.dart
@@ -1,4 +1,5 @@
 import 'package:boxify/app_core.dart';
+import 'package:boxify/screens/player/widgets/large_player_skeleton.dart';
 import 'package:boxify/screens/player/widgets/small_player_skeleton.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -12,6 +13,9 @@ class Player extends StatelessWidget {
   Widget build(BuildContext context) {
     return BlocBuilder<PlayerBloc, MyPlayerState>(builder: (context, state) {
       final index = state.player.currentIndex;
+      final width = MediaQuery.of(context).size.width;
+      final isLargeScreen = width >= Core.app.largeSmallBreakpoint;
+
       if (state.status == PlayerStatus.error) {
         logger.e('SmallPlayer.build() - PlayerStatus == error');
         return ErrorDialog(content: state.status.toString());
@@ -26,7 +30,7 @@ class Player extends StatelessWidget {
           ) {
         logger.i(
             'Player - PlayerStatus == ${state.status} so returning CircularProgressIndicator()');
-        return SmallPlayerSkeleton();
+        return isLargeScreen ? LargePlayerSkeleton() : SmallPlayerSkeleton();
       } else {
         /// Get the [Track] from the player.audiosource that is currently playing,
         /// or the first track in the PlayerState.queue if no track is playing
@@ -46,8 +50,6 @@ class Player extends StatelessWidget {
                 assignPlaylistImageUrlToTrack(track, enquedPlaylist);
             final imageFilename =
                 assignPlaylistImageFilenameToTrack(track, enquedPlaylist);
-            final width = MediaQuery.of(context).size.width;
-            final isLargeScreen = width >= Core.app.largeSmallBreakpoint;
             return isLargeScreen
                 ? LargePlayer(
                     imageUrl: imageUrl,

--- a/lib/screens/player/widgets/large_player_skeleton.dart
+++ b/lib/screens/player/widgets/large_player_skeleton.dart
@@ -1,0 +1,70 @@
+import 'dart:math';
+import 'package:boxify/app_core.dart';
+import 'package:flutter/material.dart';
+import 'package:shimmer/shimmer.dart';
+
+/// LargePlayerSkeleton
+/// This is a placeholder for the LargePlayer, displayed while waiting for tracks to be loaded
+class LargePlayerSkeleton extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    // Assume the minimum screen size is 500 pixels
+    final minScreenSize = min(MediaQuery.of(context).size.width, 500);
+    return Container(
+      color: Core.appColor.scaffoldBackgroundColor,
+      height: Core.app.playerHeight,
+      padding: const EdgeInsets.fromLTRB(20, 0, 20, 0),
+      child: Row(children: [
+        Padding(
+          padding: const EdgeInsets.all(5),
+          child: Shimmer.fromColors(
+            // Track image skeleton
+            baseColor: Core.appColor.shimmerBaseColor,
+            highlightColor: Core.appColor.shimmerHighlightColor,
+            child: Container(
+              height: Core.app.smallRowImageSize,
+              width: Core.app.smallRowImageSize,
+              decoration: BoxDecoration(color: Colors.grey[300]),
+            ),
+          ),
+        ),
+        Expanded(
+          child: Padding(
+            padding: const EdgeInsets.all(5),
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Shimmer.fromColors(
+                  baseColor: Core.appColor.shimmerBaseColor,
+                  highlightColor: Core.appColor.shimmerHighlightColor,
+                  child: Container(
+                    height: 14,
+                    width: minScreenSize * 0.3,
+                    decoration: BoxDecoration(
+                      color: Colors.grey[300],
+                      borderRadius: BorderRadius.circular(8),
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 5),
+                Shimmer.fromColors(
+                  baseColor: Core.appColor.shimmerBaseColor,
+                  highlightColor: Core.appColor.shimmerHighlightColor,
+                  child: Container(
+                    height: 12,
+                    width: minScreenSize * 0.18,
+                    decoration: BoxDecoration(
+                      color: Colors.grey[300],
+                      borderRadius: BorderRadius.circular(8),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ]),
+    );
+  }
+}

--- a/lib/screens/player/widgets/small_player_skeleton.dart
+++ b/lib/screens/player/widgets/small_player_skeleton.dart
@@ -29,6 +29,7 @@ class SmallPlayerSkeleton extends StatelessWidget {
         Padding(
           padding: const EdgeInsets.all(5),
           child: Shimmer.fromColors(
+            // Track image skeleton
             baseColor: SmallPlayerSkeleton.shimmerBaseColor,
             highlightColor: SmallPlayerSkeleton.shimmerHighlightColor,
             child: Container(
@@ -49,6 +50,7 @@ class SmallPlayerSkeleton extends StatelessWidget {
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 Shimmer.fromColors(
+                  // Track title skeleton
                   baseColor: SmallPlayerSkeleton.shimmerBaseColor,
                   highlightColor: SmallPlayerSkeleton.shimmerHighlightColor,
                   child: Container(
@@ -62,6 +64,7 @@ class SmallPlayerSkeleton extends StatelessWidget {
                 ),
                 const SizedBox(height: 5),
                 Shimmer.fromColors(
+                  // Track artist skeleton
                   baseColor: SmallPlayerSkeleton.shimmerBaseColor,
                   highlightColor: SmallPlayerSkeleton.shimmerHighlightColor,
                   child: Container(

--- a/lib/screens/player/widgets/small_player_skeleton.dart
+++ b/lib/screens/player/widgets/small_player_skeleton.dart
@@ -1,0 +1,83 @@
+import 'package:boxify/app_core.dart';
+import 'package:boxify/helpers/color_helper.dart';
+import 'package:flutter/material.dart';
+import 'package:shimmer/shimmer.dart';
+
+/// SmallPlayerSkeleton
+/// This is a placeholder for the SmallPlayer, displayed while waiting for playlists and tracks to be loaded
+class SmallPlayerSkeleton extends StatelessWidget {
+  static final Color shimmerBaseColor = Colors.grey[300]!.withOpacity(0.5);
+  static final Color shimmerHighlightColor =
+      SmallPlayerSkeleton.shimmerBaseColor.withOpacity(0.35);
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(8),
+        color: ColorHelper.dimColor(Core.appColor.primary, dimFactor: 0.25),
+        boxShadow: const [
+          BoxShadow(
+            blurRadius: 2,
+            spreadRadius: 5,
+            offset: Offset(2, 2),
+          )
+        ],
+      ),
+      height: Core.app.smallPlayerHeight,
+      child: Row(children: [
+        Padding(
+          padding: const EdgeInsets.all(5),
+          child: Shimmer.fromColors(
+            baseColor: SmallPlayerSkeleton.shimmerBaseColor,
+            highlightColor: SmallPlayerSkeleton.shimmerHighlightColor,
+            child: Container(
+              height: Core.app.smallRowImageSize,
+              width: Core.app.smallRowImageSize,
+              decoration: BoxDecoration(
+                color: Colors.grey[300],
+                borderRadius: BorderRadius.circular(8),
+              ),
+            ),
+          ),
+        ),
+        Expanded(
+          child: Padding(
+            padding: const EdgeInsets.all(5),
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Shimmer.fromColors(
+                  baseColor: SmallPlayerSkeleton.shimmerBaseColor,
+                  highlightColor: SmallPlayerSkeleton.shimmerHighlightColor,
+                  child: Container(
+                    height: 14,
+                    width: MediaQuery.of(context).size.width * 0.5,
+                    decoration: BoxDecoration(
+                      color: Colors.grey[300],
+                      borderRadius: BorderRadius.circular(8),
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 5),
+                Shimmer.fromColors(
+                  baseColor: SmallPlayerSkeleton.shimmerBaseColor,
+                  highlightColor: SmallPlayerSkeleton.shimmerHighlightColor,
+                  child: Container(
+                    height: 12,
+                    width: MediaQuery.of(context).size.width * 0.3,
+                    decoration: BoxDecoration(
+                      color: Colors.grey[300],
+                      borderRadius: BorderRadius.circular(8),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ]),
+    );
+  }
+}

--- a/lib/screens/playlist/base_playlist_screen.dart
+++ b/lib/screens/playlist/base_playlist_screen.dart
@@ -99,94 +99,93 @@ class _BasePlaylistScreenState extends State<BasePlaylistScreen>
     return BlocBuilder<PlaylistBloc, PlaylistState>(
       builder: (context, state) {
         final status = state.status;
-        if (playlistStatusIsLoaded(status)) {
-          final playlistBloc = context.read<PlaylistBloc>();
-          final trackBloc = context.read<TrackBloc>();
-          final displayedTracks = trackBloc.state.displayedTracks;
+        final playlistBloc = context.read<PlaylistBloc>();
+        final trackBloc = context.read<TrackBloc>();
+        final playlist = playlistBloc.state.viewedPlaylist;
 
-          final containsDownloaded = displayedTracks.any((element) =>
-              element.downloadedUrl != null &&
-              element.downloadedUrl!
-                  .toLowerCase()
-                  .contains('file')); // Added null check for downloadedUrl
-          final containsAvailable = displayedTracks.any((element) =>
-              element.link != null &&
-              element.link!.isNotEmpty); // Added null check for link
+        final displayedTracks = trackBloc.state.displayedTracks;
+        final isPlaylistLoaded = playlistStatusIsLoaded(status);
 
-          final playlist = playlistBloc.state.viewedPlaylist;
+        final containsDownloaded = displayedTracks.any((element) =>
+            element.downloadedUrl != null &&
+            element.downloadedUrl!
+                .toLowerCase()
+                .contains('file')); // Added null check for downloadedUrl
 
-          if (playlist == null) {
-            return Container(
-              color: Core.appColor.widgetBackgroundColor,
-              child: Center(child: CircularProgressIndicator()),
-            );
-          } else if (playlist.displayTitle == Playlist.empty.displayTitle) {
-            return ErrorPage();
-          }
+        final containsAvailable = displayedTracks.any((element) =>
+            element.link != null &&
+            element.link!.isNotEmpty); // Added null check for link
 
-          final device = MediaQuery.of(context);
-          final isSmall = device.size.width < Core.app.largeSmallBreakpoint;
+        if (playlist == null) {
+          return Container(
+            color: Core.appColor.widgetBackgroundColor,
+            child: Center(child: CircularProgressIndicator()),
+          );
+        } else if (playlist.displayTitle == Playlist.empty.displayTitle) {
+          return ErrorPage();
+        }
 
-          final isNativePlatform = !kIsWeb;
-          final isMouse = !isNativePlatform && !isSmall;
-          List<Widget> trackMouseRowItems = [];
-          if (isMouse) {
-            final trackMouseRowHelper = TrackMouseRowHelper();
+        final device = MediaQuery.of(context);
+        final isSmall = device.size.width < Core.app.largeSmallBreakpoint;
 
-            // Fetch the list of row items with dragging logic
-            trackMouseRowItems = trackMouseRowHelper.getTrackMouseRowItems(
-              context,
-              canBeADragTarget: kIsWeb,
-              canDrag: kIsWeb,
-              trackRowType: TrackRowType.displayedTracks,
-            );
-          }
+        final isNativePlatform = !kIsWeb;
+        final isMouse = !isNativePlatform && !isSmall;
+        List<Widget> trackMouseRowItems = [];
+        if (isMouse) {
+          final trackMouseRowHelper = TrackMouseRowHelper();
 
-          return BlocProvider(
-            create: (context) => DraggingCubit(),
-            child: SafeArea(
-              child: CustomScrollView(
-                controller: scrollController,
-                slivers: [
-                  isNativePlatform || isSmall
-                      ? SliverAppBarExpandable(
-                          expandedHeight: expandedHeight,
-                          appBarBackgroundOpacity: appBarBackgroundOpacity,
-                          titleOpacity: titleOpacity,
-                          imageUrl: playlist.imageUrl,
-                          title: playlist.displayTitle ?? '',
-                          imageFilename: playlist.imageFilename,
-                          color: playlist.backgroundColor,
-                        )
-                      : SliverAppBarNoExpand(
-                          type: SliverAppBarNoExpandType.playlist,
-                          expandedHeight: kToolbarHeight,
-                          appBarBackgroundOpacity: appBarBackgroundOpacity,
-                          titleOpacity: titleOpacity,
-                          title: playlist.displayTitle!,
-                          color: playlist.backgroundColor,
-                        ),
-                  if (isNativePlatform || isSmall)
-                    PlaylistTouchScreen(
-                      playlist: playlist,
-                      containsDownloaded: containsDownloaded,
-                      containsAvailable: containsAvailable,
-                    )
-                  else
-                    ...PlaylistMouseScreen.buildSlivers(
+          // Fetch the list of row items with dragging logic
+          trackMouseRowItems = trackMouseRowHelper.getTrackMouseRowItems(
+            context,
+            canBeADragTarget: kIsWeb,
+            canDrag: kIsWeb,
+            trackRowType: TrackRowType.displayedTracks,
+          );
+        }
+
+        return BlocProvider(
+          create: (context) => DraggingCubit(),
+          child: SafeArea(
+            child: CustomScrollView(
+              controller: scrollController,
+              slivers: [
+                isNativePlatform || isSmall
+                    ? SliverAppBarExpandable(
+                        expandedHeight: expandedHeight,
+                        appBarBackgroundOpacity: appBarBackgroundOpacity,
+                        titleOpacity: titleOpacity,
+                        imageUrl: playlist.imageUrl,
+                        title: playlist.displayTitle ?? '',
+                        imageFilename: playlist.imageFilename,
+                        color: playlist.backgroundColor,
+                      )
+                    : SliverAppBarNoExpand(
+                        type: SliverAppBarNoExpandType.playlist,
+                        expandedHeight: kToolbarHeight,
+                        appBarBackgroundOpacity: appBarBackgroundOpacity,
+                        titleOpacity: titleOpacity,
+                        title: playlist.displayTitle!,
+                        color: playlist.backgroundColor,
+                      ),
+                if (isNativePlatform || isSmall)
+                  PlaylistTouchScreen(
+                    playlist: playlist,
+                    containsDownloaded: containsDownloaded,
+                    containsAvailable: containsAvailable,
+                    isPlaylistLoaded: isPlaylistLoaded,
+                  )
+                else
+                  ...PlaylistMouseScreen.buildSlivers(
                       context,
                       PlaylistMouseScreen(playlist: playlist),
                       playlist,
                       trackMouseRowItems,
                       containsAvailable,
-                    ),
-                ],
-              ),
+                      isPlaylistLoaded),
+              ],
             ),
-          );
-        } else {
-          return Container();
-        }
+          ),
+        );
       },
     );
   }

--- a/lib/screens/playlist/widgets/playlist_mouse_screen.dart
+++ b/lib/screens/playlist/widgets/playlist_mouse_screen.dart
@@ -1,3 +1,4 @@
+import 'package:boxify/screens/playlist/widgets/track_mouse_row_skeleton.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -20,6 +21,7 @@ class PlaylistMouseScreen extends StatefulWidget {
     Playlist playlist,
     List<Widget> trackMouseRowItems,
     bool containsAvailable,
+    bool isPlaylistLoaded,
   ) {
     return [
       DecoratedPlaylistInfoWidgets(
@@ -34,27 +36,39 @@ class PlaylistMouseScreen extends StatefulWidget {
           endColor: Core.appColor.hoverColor,
         ),
       ),
-      SliverList(
-        delegate: SliverChildBuilderDelegate(
-          (context, index) {
-            return trackMouseRowItems[index];
-          },
-          childCount: trackMouseRowItems.length,
-        ),
-      ),
+      isPlaylistLoaded
+          ? SliverList(
+              // List of track rows
+              delegate: SliverChildBuilderDelegate(
+                (context, index) {
+                  return trackMouseRowItems[index];
+                },
+                childCount: trackMouseRowItems.length,
+              ),
+            )
+          : SliverList(
+              // Skeletons for track rows
+              delegate: SliverChildBuilderDelegate(
+                (context, index) {
+                  return TrackMouseRowSkeleton();
+                },
+                childCount: 10,
+              ),
+            ),
       SliverToBoxAdapter(
-        child:
-            Core.app.type == AppType.advanced && playlist.isOwnPlaylist == true
-                ? LetsAddSomething()
-                : trackMouseRowItems.isEmpty
-                    ? (playlist.id == Core.app.newReleasesPlaylistId
-                        ? CenteredText('noNewReleasesMessage'.translate())
-                        : (playlist.id?.contains('_4star') == true
-                            ? CenteredText('no4StarTracks'.translate())
-                            : (playlist.id?.contains('_5star') == true
-                                ? CenteredText('no5StarTracks'.translate())
-                                : CenteredText('noTracksMessage'.translate()))))
-                    : Container(),
+        child: Core.app.type == AppType.advanced &&
+                isPlaylistLoaded &&
+                playlist.isOwnPlaylist == true
+            ? LetsAddSomething()
+            : trackMouseRowItems.isEmpty
+                ? (playlist.id == Core.app.newReleasesPlaylistId
+                    ? CenteredText('noNewReleasesMessage'.translate())
+                    : (playlist.id?.contains('_4star') == true
+                        ? CenteredText('no4StarTracks'.translate())
+                        : (playlist.id?.contains('_5star') == true
+                            ? CenteredText('no5StarTracks'.translate())
+                            : CenteredText('noTracksMessage'.translate()))))
+                : Container(),
       ),
     ];
   }
@@ -97,8 +111,8 @@ class _PlaylistMouseScreenState extends State<PlaylistMouseScreen> {
     return BlocProvider(
       create: (context) => DraggingCubit(),
       child: CustomScrollView(
-        slivers: PlaylistMouseScreen.buildSlivers(
-            context, widget, playlist, trackMouseRowItems, containsAvailable),
+        slivers: PlaylistMouseScreen.buildSlivers(context, widget, playlist,
+            trackMouseRowItems, containsAvailable, true),
       ),
     );
   }

--- a/lib/screens/playlist/widgets/small_playlist_tools.dart
+++ b/lib/screens/playlist/widgets/small_playlist_tools.dart
@@ -10,10 +10,12 @@ class SmallPlaylistTools extends StatelessWidget {
     super.key,
     required this.containsDownloaded,
     required this.containsAvailable,
+    required this.isPlaylistLoaded,
   });
 
   final bool containsDownloaded;
   final bool containsAvailable;
+  final bool isPlaylistLoaded;
 
   @override
   Widget build(BuildContext context) {
@@ -42,8 +44,8 @@ class SmallPlaylistTools extends StatelessWidget {
               OverflowIconForPlaylist(playlist: playlist),
             ],
           ),
-          if (trackBloc.state.displayedTracks.isNotEmpty)
-            SmallPlaylistPlayerControls(),
+          if (trackBloc.state.displayedTracks.isNotEmpty || !isPlaylistLoaded)
+            SmallPlaylistPlayerControls(isPlaylistLoaded: isPlaylistLoaded),
         ],
       ),
     );

--- a/lib/screens/playlist/widgets/track_mouse_row_skeleton.dart
+++ b/lib/screens/playlist/widgets/track_mouse_row_skeleton.dart
@@ -1,0 +1,82 @@
+import 'package:boxify/app_core.dart';
+import 'package:flutter/material.dart';
+import 'package:shimmer/shimmer.dart';
+
+/// TrackMouseRowSkeleton
+/// This is a [TrackMouseRow] placeholder, displayed while waiting for tracks to be loaded
+class TrackMouseRowSkeleton extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.fromLTRB(16, 7, 16, 7),
+      color: Core.appColor.widgetBackgroundColor,
+      child: Row(
+        children: [
+          Shimmer.fromColors(
+            // Skeleton for track index text
+            baseColor: Core.appColor.shimmerBaseColor,
+            highlightColor: Core.appColor.shimmerHighlightColor,
+            child: Container(
+              height: 15,
+              width: 15,
+              decoration: BoxDecoration(
+                color: Colors.grey[300],
+                borderRadius: BorderRadius.circular(8),
+              ),
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.fromLTRB(10, 0, 5, 0),
+            child: Shimmer.fromColors(
+              baseColor: Core.appColor.shimmerBaseColor,
+              highlightColor: Core.appColor.shimmerHighlightColor,
+              child: Container(
+                height: 42.0,
+                width: 42.0,
+                decoration: BoxDecoration(
+                    color: Colors.grey[300],
+                    borderRadius: BorderRadius.circular(8)),
+              ),
+            ),
+          ),
+          Expanded(
+            child: Padding(
+              padding: const EdgeInsets.all(5),
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Shimmer.fromColors(
+                    baseColor: Core.appColor.shimmerBaseColor,
+                    highlightColor: Core.appColor.shimmerHighlightColor,
+                    child: Container(
+                      height: 14,
+                      width: 200,
+                      decoration: BoxDecoration(
+                        color: Colors.grey[300],
+                        borderRadius: BorderRadius.circular(8),
+                      ),
+                    ),
+                  ),
+                  const SizedBox(height: 5),
+                  Shimmer.fromColors(
+                    baseColor: Core.appColor.shimmerBaseColor,
+                    highlightColor: Core.appColor.shimmerHighlightColor,
+                    child: Container(
+                      height: 10,
+                      width: 100,
+                      decoration: BoxDecoration(
+                        color: Colors.grey[300],
+                        borderRadius: BorderRadius.circular(8),
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/screens/playlist/widgets/track_touch_row_skeleton.dart
+++ b/lib/screens/playlist/widgets/track_touch_row_skeleton.dart
@@ -1,0 +1,67 @@
+import 'package:boxify/app_core.dart';
+import 'package:flutter/material.dart';
+import 'package:shimmer/shimmer.dart';
+
+/// TrackTouchRowSkeleton
+/// This is a [TrackTouchRow] placeholder, displayed while waiting for tracks to be loaded
+class TrackTouchRowSkeleton extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.fromLTRB(16, 7, 16, 7),
+      color: Core.appColor.widgetBackgroundColor,
+      child: Row(
+        children: [
+          Padding(
+            padding: const EdgeInsets.fromLTRB(0, 0, 10, 0),
+            child: Shimmer.fromColors(
+              baseColor: Core.appColor.shimmerBaseColor,
+              highlightColor: Core.appColor.shimmerHighlightColor,
+              child: Container(
+                height: Core.app.smallRowImageSize,
+                width: Core.app.smallRowImageSize,
+                decoration: BoxDecoration(color: Colors.grey[300]),
+              ),
+            ),
+          ),
+          Expanded(
+            child: Padding(
+              padding: const EdgeInsets.all(5),
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Shimmer.fromColors(
+                    baseColor: Core.appColor.shimmerBaseColor,
+                    highlightColor: Core.appColor.shimmerHighlightColor,
+                    child: Container(
+                      height: 14,
+                      width: MediaQuery.of(context).size.width * 0.35,
+                      decoration: BoxDecoration(
+                        color: Colors.grey[300],
+                        borderRadius: BorderRadius.circular(8),
+                      ),
+                    ),
+                  ),
+                  const SizedBox(height: 10),
+                  Shimmer.fromColors(
+                    baseColor: Core.appColor.shimmerBaseColor,
+                    highlightColor: Core.appColor.shimmerHighlightColor,
+                    child: Container(
+                      height: 10,
+                      width: MediaQuery.of(context).size.width * 0.18,
+                      decoration: BoxDecoration(
+                        color: Colors.grey[300],
+                        borderRadius: BorderRadius.circular(8),
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          )
+        ],
+      ),
+    );
+  }
+}

--- a/lib/screens/playlist/widgets/track_touch_row_skeleton.dart
+++ b/lib/screens/playlist/widgets/track_touch_row_skeleton.dart
@@ -36,7 +36,7 @@ class TrackTouchRowSkeleton extends StatelessWidget {
                     highlightColor: Core.appColor.shimmerHighlightColor,
                     child: Container(
                       height: 14,
-                      width: MediaQuery.of(context).size.width * 0.35,
+                      width: 150,
                       decoration: BoxDecoration(
                         color: Colors.grey[300],
                         borderRadius: BorderRadius.circular(8),
@@ -49,7 +49,7 @@ class TrackTouchRowSkeleton extends StatelessWidget {
                     highlightColor: Core.appColor.shimmerHighlightColor,
                     child: Container(
                       height: 10,
-                      width: MediaQuery.of(context).size.width * 0.18,
+                      width: 80,
                       decoration: BoxDecoration(
                         color: Colors.grey[300],
                         borderRadius: BorderRadius.circular(8),

--- a/lib/screens/scafffold_with_player.dart
+++ b/lib/screens/scafffold_with_player.dart
@@ -288,27 +288,6 @@ class ScaffoldWithPlayer extends StatelessWidget {
                                           message: state.errorMessage!,
                                           color: Colors.red);
                                     } else if (state.status ==
-                                        DownloadStatus.syncingDownloads) {
-                                      showMySnack(
-                                        context,
-                                        message: 'Syncing downloads on WiFi'
-                                            .translate(),
-                                        color: Core.appColor.primary,
-                                      );
-                                    } else if (state.status ==
-                                        DownloadStatus
-                                            .syncingDownloadsCompleted) {
-                                      // Only show "Downloads synced" if we're not currently removing downloads
-                                      if (_lastHandledStatus !=
-                                          DownloadStatus.removing) {
-                                        showMySnack(
-                                          context,
-                                          message:
-                                              'Downloads synced'.translate(),
-                                          color: Core.appColor.primary,
-                                        );
-                                      }
-                                    } else if (state.status ==
                                         DownloadStatus.completed) {
                                       showMySnack(
                                         context,

--- a/lib/screens/search_music/widgets/search_results.dart
+++ b/lib/screens/search_music/widgets/search_results.dart
@@ -1,4 +1,5 @@
 import 'package:boxify/app_core.dart';
+import 'package:boxify/screens/playlist/widgets/track_mouse_row_skeleton.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
@@ -9,34 +10,49 @@ class LargeTrackSearchResults extends StatelessWidget {
     required this.screenType,
     required bool isLargeScreen,
     required this.itemCount,
+    required this.showLoadingState,
   }) : _isLargeScreen = isLargeScreen;
 
   final double screenType;
   final bool _isLargeScreen;
   final int itemCount;
+  final bool showLoadingState;
 
   @override
   Widget build(BuildContext context) {
+    // If tracks are loading, show a loading state (skeleton)
+
     return ListView(
       children: [
         SizedBox(height: Core.app.appBarHeight * screenType),
         _isLargeScreen
             ? LargePlaylistQueueHeaders(showYear: false)
             : Container(),
-
-        /// Expanded is causing a space???
-        SizedBox(
-          height: Core.app.largeScreenRowHeight * itemCount,
-          child: TrackMouseRowHelper().getTrackMouseRows(
-            context,
-            innerItemsAreScrollable: false,
-            canDrag:
-                kIsWeb, // You actually can't drag search results on a longPress, just on a click
-            canBeADragTarget: false,
-            replaceSelectedTracksWithSearchResultsOnTap: true,
-            trackRowType: TrackRowType.searchResultsForSearchScreen,
-          ),
-        ),
+        showLoadingState
+            ? SizedBox(
+                // Loading state with 3 skeleton rows
+                height: Core.app.largeScreenRowHeight * 3,
+                child: ListView.builder(
+                  shrinkWrap: true,
+                  physics: NeverScrollableScrollPhysics(),
+                  itemCount: 3,
+                  itemBuilder: (context, i) {
+                    return TrackMouseRowSkeleton();
+                  },
+                ))
+            : SizedBox(
+                // Actual search results
+                height: Core.app.largeScreenRowHeight * itemCount,
+                child: TrackMouseRowHelper().getTrackMouseRows(
+                  context,
+                  innerItemsAreScrollable: false,
+                  canDrag:
+                      kIsWeb, // You actually can't drag search results on a longPress, just on a click
+                  canBeADragTarget: false,
+                  replaceSelectedTracksWithSearchResultsOnTap: true,
+                  trackRowType: TrackRowType.searchResultsForSearchScreen,
+                ),
+              ),
       ],
     );
   }

--- a/lib/screens/search_music/widgets/small_track_search_results.dart
+++ b/lib/screens/search_music/widgets/small_track_search_results.dart
@@ -1,4 +1,5 @@
 import 'package:boxify/app_core.dart';
+import 'package:boxify/screens/playlist/widgets/track_touch_row_skeleton.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
@@ -10,9 +11,11 @@ class SmallTrackSearchResults extends StatelessWidget {
   const SmallTrackSearchResults({
     super.key,
     this.screenType = SearchResultType.searchScreen,
+    this.showLoadingState = false,
   });
 
   final SearchResultType screenType;
+  final bool showLoadingState;
 
   @override
   Widget build(BuildContext context) {
@@ -46,8 +49,15 @@ class SmallTrackSearchResults extends StatelessWidget {
 
     return BlocBuilder<SearchBloc, SearchState>(
       builder: (context, state) {
-        if (state.status == SearchStatus.loading) {
-          return const Center(child: CircularProgressIndicator());
+        if (showLoadingState) {
+          return ListView.builder(
+            shrinkWrap: true,
+            physics: NeverScrollableScrollPhysics(),
+            itemCount: 3,
+            itemBuilder: (context, i) {
+              return TrackTouchRowSkeleton();
+            },
+          );
         }
         if (state.status == SearchStatus.error) {
           return Center(child: Text('errorLoadingTracks'.translate()));

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -88,6 +88,7 @@ dependencies:
   upgrader: ^8.2.0
   validators: ^3.0.0  
   material_design_icons_flutter: 7.0.7296
+  shimmer: ^3.0.0
 
 dependency_overrides:
   modal_bottom_sheet: ^3.0.0-pre


### PR DESCRIPTION
I've been working on this for the past week, and it is finally stable! It's a pretty big PR but should lay the groundwork for a lot of exciting features that we will be able to implement on top of this in the future (like only loading what's necessary for the user).

**The main goal of this PR** is to load all tracks in the background while allowing the user to navigate the UI instead of being stuck on a loading screen. This significantly **reduces the initial loading** **time** and makes the **overall user experience feel much smoother** at startup.

## New loading effect
When tracks aren't loaded, the user can't see the player, search for tracks or open playlists - instead a Skeleton is displayed. This technique is used by most major apps (Google, Discord, etc.) by showing a **preview** of the data being loaded - and gives the illusion that the loading time is much shorter.

Here's how it looks, when simulating a very slow internet connection:

https://github.com/user-attachments/assets/77df537a-23f0-44dc-a9a9-9814fbee7c1c

Without this change, the user would have been stuck with a long loading screen before being able to use the app.
This change has been implemented both on web and on large screens, since the UIs there are different.

## Search Screen
It also works on the search page (and executes the search automatically once the tracks have been loaded):

![weezify_gif_done2-ezgif com-resize](https://github.com/user-attachments/assets/c6f991f8-fc19-4714-9c42-791914cd7652)

## Showcase
| Playlist | Search | Player |
|---|---|---|
|![boxifyshowcase1-ezgif com-crop](https://github.com/user-attachments/assets/3816ef44-d37f-4f56-8ada-9e82e1eeb0da)|![boxifyshowcase2-ezgif com-crop](https://github.com/user-attachments/assets/bc6287bd-6b24-4000-bcab-42961bf5fac0)|![boxifyshowcase3-ezgif com-crop](https://github.com/user-attachments/assets/3ca8379b-42a2-4cad-a1c5-4a63d1064cba)|

## Details
This is the first phase of a broader project (as detailed in https://github.com/riverscuomo/boxify/discussions/104) and should be by far the largest PR.

Overall, this change should reduce the initial loading time with no cache by 70%-90% depending on the user's internet speed. I've also done a few optimizations, but nothing too major as I tried to avoid altering the code too much.

> **NOTE:** I've used a new Shimmer library, it's very light - but updating local flutter packages may be necessary to start Boxify.

Let me know if there are any questions or remarks about this implementation!
