### PR TITLE
Removing more purple

### DIFF
--- a/lib/base_app.dart
+++ b/lib/base_app.dart
@@ -413,6 +413,7 @@ class BaseColor {
   get header => Colors.black;
   Color get text => Colors.white;
   Color get navBar => Colors.white;
+  Color get icon => Colors.white;
   Color get iconButton => const Color(0xFF999999);
   Color get barrier => Colors.black38;
   Color get separator => const Color(0xFFeeeeee);

--- a/lib/base_app.dart
+++ b/lib/base_app.dart
@@ -414,6 +414,8 @@ class BaseColor {
   Color get text => Colors.white;
   Color get navBar => Colors.white;
   Color get icon => Colors.white;
+  Color get hintText => const Color(0XFFCCCCCC); // lightGrey
+  Color get focusBorder => Colors.white;
   Color get iconButton => const Color(0xFF999999);
   Color get barrier => Colors.black38;
   Color get separator => const Color(0xFFeeeeee);

--- a/lib/base_app.dart
+++ b/lib/base_app.dart
@@ -415,7 +415,7 @@ class BaseColor {
   Color get navBar => Colors.white;
   Color get icon => Colors.white;
   Color get hintText => const Color(0XFFCCCCCC); // lightGrey
-  Color get focusBorder => Colors.white;
+  Color get focusedBorder => Colors.white;
   Color get iconButton => const Color(0xFF999999);
   Color get barrier => Colors.black38;
   Color get separator => const Color(0xFFeeeeee);

--- a/lib/screens/playlist/widgets/large_playlist_info.dart
+++ b/lib/screens/playlist/widgets/large_playlist_info.dart
@@ -99,6 +99,12 @@ class _LargePlaylistInfoState extends State<LargePlaylistInfo>
                       controller: titleController,
                       decoration: const InputDecoration(
                         border: OutlineInputBorder(),
+                        focusedBorder: OutlineInputBorder(
+                          borderSide: BorderSide(
+                            color: Colors.white, // couldn't use Core in const
+                            width: 2.0
+                          ),
+                        ),
                         // hintText: state.viewedPlaylist!.name,
                       ),
                     ),
@@ -112,6 +118,12 @@ class _LargePlaylistInfoState extends State<LargePlaylistInfo>
                       controller: descriptionController,
                       decoration: const InputDecoration(
                         border: OutlineInputBorder(),
+                        focusedBorder: OutlineInputBorder(
+                          borderSide: BorderSide(
+                            color: Colors.white, // couldn't use core in const
+                            width: 2.0
+                          ),
+                        ),
                         hintText: 'Add an optional description',
                       ),
                     ),
@@ -303,3 +315,4 @@ class _LargePlaylistInfoState extends State<LargePlaylistInfo>
     );
   }
 }
+

--- a/lib/screens/playlist/widgets/large_playlist_info.dart
+++ b/lib/screens/playlist/widgets/large_playlist_info.dart
@@ -97,11 +97,11 @@ class _LargePlaylistInfoState extends State<LargePlaylistInfo>
                     child: TextFormField(
                       // initialValue: titleController.text,
                       controller: titleController,
-                      decoration: const InputDecoration(
+                      decoration:  InputDecoration(
                         border: OutlineInputBorder(),
                         focusedBorder: OutlineInputBorder(
                           borderSide: BorderSide(
-                            color: Colors.white, // couldn't use Core in const
+                            color: Core.appColor.focusedBorder,
                             width: 2.0
                           ),
                         ),
@@ -116,11 +116,11 @@ class _LargePlaylistInfoState extends State<LargePlaylistInfo>
                     child: TextFormField(
                       // initialValue: descriptionController.text,
                       controller: descriptionController,
-                      decoration: const InputDecoration(
+                      decoration: InputDecoration(
                         border: OutlineInputBorder(),
                         focusedBorder: OutlineInputBorder(
                           borderSide: BorderSide(
-                            color: Colors.white, // couldn't use core in const
+                            color: Core.appColor.focusedBorder, 
                             width: 2.0
                           ),
                         ),

--- a/lib/screens/settings/buttons/discord.dart
+++ b/lib/screens/settings/buttons/discord.dart
@@ -48,6 +48,12 @@ class DiscordFormField extends StatelessWidget {
         decoration: InputDecoration(
           hintMaxLines: 3,
           border: const OutlineInputBorder(),
+          focusedBorder: OutlineInputBorder(
+            borderSide: BorderSide(
+              color: Core.appColor.focusBorder,
+              width: 2.0
+            ),
+          ),
           hintText: user.discordId.isNotEmpty
               ? user.discordId
               : 'discordHintText'.translate(),

--- a/lib/screens/settings/buttons/discord.dart
+++ b/lib/screens/settings/buttons/discord.dart
@@ -50,7 +50,7 @@ class DiscordFormField extends StatelessWidget {
           border: const OutlineInputBorder(),
           focusedBorder: OutlineInputBorder(
             borderSide: BorderSide(
-              color: Core.appColor.focusBorder,
+              color: Core.appColor.focusedBorder,
               width: 2.0
             ),
           ),

--- a/lib/theme/boxify_theme.dart
+++ b/lib/theme/boxify_theme.dart
@@ -50,7 +50,7 @@ class BoxifyTheme {
       inputDecorationTheme: InputDecorationTheme(
         focusedBorder: UnderlineInputBorder(
           borderSide: BorderSide(
-            color: Core.appColor.focusBorder, 
+            color: Core.appColor.focusedBorder, 
             width: 2.0
           ),
         ),

--- a/lib/theme/boxify_theme.dart
+++ b/lib/theme/boxify_theme.dart
@@ -28,13 +28,34 @@ class BoxifyTheme {
           foregroundColor: Core.appColor.text,
         ),
       ),
-      iconTheme: IconThemeData(color: Core.appColor.text),
       appBarTheme: AppBarTheme(
-        iconTheme: IconThemeData(color: Core.appColor.text),
+        iconTheme: IconThemeData(color: Core.appColor.icon),
       ),
       snackBarTheme: SnackBarThemeData(
         actionTextColor: Core.appColor.text,
       ),
+       textSelectionTheme: TextSelectionThemeData(
+        cursorColor: Core.appColor.text,
+        selectionColor: Core.appColor.text.withOpacity(0.5),
+        selectionHandleColor: Core.appColor.text,
+      ),
+      progressIndicatorTheme: ProgressIndicatorThemeData(
+        color: Core.appColor.primary
+      ),
+      inputDecorationTheme: InputDecorationTheme(
+        focusedBorder: UnderlineInputBorder(
+          borderSide: BorderSide(
+            color: Core.appColor.text, 
+            width: 2.0
+          ),
+        ),
+        enabledBorder: UnderlineInputBorder(
+          borderSide: BorderSide(
+            color: Core.appColor.text
+          ),
+        ),
+        hintStyle: TextStyle(color: Core.appColor.lightGrey)
+      ), 
     );
   }
 }

--- a/lib/theme/boxify_theme.dart
+++ b/lib/theme/boxify_theme.dart
@@ -28,16 +28,21 @@ class BoxifyTheme {
           foregroundColor: Core.appColor.text,
         ),
       ),
+      iconTheme: IconThemeData(
+        color: Core.appColor.icon,
+      ),
       appBarTheme: AppBarTheme(
-        iconTheme: IconThemeData(color: Core.appColor.icon),
+        iconTheme: IconThemeData(
+          color: Core.appColor.icon
+        ),
       ),
       snackBarTheme: SnackBarThemeData(
         actionTextColor: Core.appColor.text,
       ),
-       textSelectionTheme: TextSelectionThemeData(
-        cursorColor: Core.appColor.text,
+      textSelectionTheme: TextSelectionThemeData(
+        cursorColor: Core.appColor.icon,
         selectionColor: Core.appColor.text.withOpacity(0.5),
-        selectionHandleColor: Core.appColor.text,
+        selectionHandleColor: Core.appColor.icon,
       ),
       progressIndicatorTheme: ProgressIndicatorThemeData(
         color: Core.appColor.primary
@@ -45,17 +50,17 @@ class BoxifyTheme {
       inputDecorationTheme: InputDecorationTheme(
         focusedBorder: UnderlineInputBorder(
           borderSide: BorderSide(
-            color: Core.appColor.text, 
+            color: Core.appColor.focusBorder, 
             width: 2.0
           ),
         ),
-        enabledBorder: UnderlineInputBorder(
-          borderSide: BorderSide(
-            color: Core.appColor.text
-          ),
+        labelStyle: TextStyle(
+          color: Core.appColor.hintText
+        ), 
+        hintStyle: TextStyle(
+          color: Core.appColor.hintText
         ),
-        hintStyle: TextStyle(color: Core.appColor.lightGrey)
-      ), 
+      ),
     );
   }
 }


### PR DESCRIPTION
Try not to close the corresponding issue when this PR is closed. I'll rather mark the issue 'FIXED IN NEXT BETA' when I merge the PR.
~ Rivers
I ran through the app both on android simulator and webapp from sign up to account deletion.  Tried to use all forms and buttons and text fields. Tried to cause all dialogs and errors.  This should remove all remaining purple and replace with white or grey or primary like the rest of the app.   

The three text fields with `outlineBorder` I had to go and adjust individually because globally I could only set either `underlineInputBorder` OR `outlineInputBorder` .  And there were many more` underline` so I chose that globally.