### PR TITLE
Improve track background color

### DIFF
--- a/lib/blocs/player/my_player_state.dart
+++ b/lib/blocs/player/my_player_state.dart
@@ -16,12 +16,16 @@ class MyPlayerState extends Equatable {
   final PlayerStatus status;
   final Failure failure;
   final AudioPlayer player;
+  // Background color, extracted from the track's cover image
+  // We use HSLColor so operations to adjust lightness are more efficient (avoids unecessary conversions)
+  final HSLColor backgroundColor;
   List<Track> queue;
 
   MyPlayerState({
     required this.status,
     required this.failure,
     required this.player,
+    required this.backgroundColor,
     required this.queue,
   });
 
@@ -32,6 +36,7 @@ class MyPlayerState extends Equatable {
       status: PlayerStatus.initial,
       failure: const Failure(),
       player: player,
+      backgroundColor: HSLColor.fromColor(Core.appColor.primary),
       queue: [],
     );
   }
@@ -41,6 +46,7 @@ class MyPlayerState extends Equatable {
         status,
         failure,
         player,
+        backgroundColor,
         queue,
       ];
 
@@ -49,12 +55,14 @@ class MyPlayerState extends Equatable {
     Failure? failure,
     AudioPlayer? player,
     ConcatenatingAudioSource? audioSource,
+    HSLColor? backgroundColor,
     List<Track>? queue,
   }) {
     return MyPlayerState(
       status: status ?? this.status,
       failure: failure ?? this.failure,
       player: player ?? this.player,
+      backgroundColor: backgroundColor ?? this.backgroundColor,
       queue: queue ?? this.queue,
     );
   }

--- a/lib/blocs/player/player_bloc.dart
+++ b/lib/blocs/player/player_bloc.dart
@@ -4,6 +4,7 @@ import 'package:bloc/bloc.dart';
 
 import 'package:boxify/app_core.dart';
 import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
 
 import 'package:flutter_bloc/flutter_bloc.dart';
 
@@ -55,6 +56,7 @@ class PlayerBloc extends Bloc<PlayerEvent, MyPlayerState> {
     on<SeekToPrevious>(_onSeekToPrevious);
     on<SeekToIndex>(_onSeekToIndex);
     on<NotifyAutoAdvance>(_onNotifyAutoAdvance);
+    on<UpdateTrackBackgroundColor>(_onUpdateTrackBackgroundColor);
 
     _discontinuitySubscription =
         _audioPlayer.positionDiscontinuityStream.listen((discontinuity) {
@@ -377,5 +379,14 @@ class PlayerBloc extends Bloc<PlayerEvent, MyPlayerState> {
     } catch (e) {
       logger.e('Error setting audio source: $e');
     }
+  }
+
+  /// Updates the background color of the player based on the track's cover image.
+  Future<void> _onUpdateTrackBackgroundColor(
+    UpdateTrackBackgroundColor event,
+    Emitter<MyPlayerState> emit,
+  ) async {
+    logger.i('_onUpdateTrackBackgroundColor');
+    emit(state.copyWith(backgroundColor: event.backgroundColor));
   }
 }

--- a/lib/blocs/player/player_event.dart
+++ b/lib/blocs/player/player_event.dart
@@ -66,6 +66,13 @@ class SeekToNext extends PlayerEvent {
   List<Object?> get props => [];
 }
 
+class UpdateTrackBackgroundColor extends PlayerEvent {
+  final HSLColor backgroundColor;
+  const UpdateTrackBackgroundColor({required this.backgroundColor});
+  @override
+  List<Object?> get props => [backgroundColor];
+}
+
 // class LogListen extends PlayerEvent {
 //   const LogListen();
 //   @override

--- a/lib/helpers/color_helper.dart
+++ b/lib/helpers/color_helper.dart
@@ -10,13 +10,9 @@ class ColorHelper {
     double maxLightness = 0.8,
   }) {
     final hslColor = HSLColor.fromColor(color);
-    double lightness = hslColor.lightness;
-    if (lightness < minLightness) {
-      return hslColor.withLightness(minLightness).toColor();
-    } else if (lightness > maxLightness) {
-      return hslColor.withLightness(maxLightness).toColor();
-    }
-    return color;
+    return ensureWithinRangeHsl(hslColor,
+            minLightness: minLightness, maxLightness: maxLightness)
+        .toColor();
   }
 
   /// Returns a "dimmed" version of the provided color.
@@ -24,7 +20,35 @@ class ColorHelper {
   /// color's lightness.
   static Color dimColor(Color color, {double dimFactor = 0.1}) {
     final hslColor = HSLColor.fromColor(color);
+    return dimColorHsl(hslColor, dimFactor: dimFactor).toColor();
+  }
+
+  /// Ensures that the provided color is not too dark or too light.
+  /// Returns the adjusted color if it is outside the specified range.
+  /// Parameters minLightness and maxLightness should be in the range 0.0 to 1.0.
+  /// This method uses the HSL color directly, which is more efficient than converting.
+  static HSLColor ensureWithinRangeHsl(
+    HSLColor hslColor, {
+    double minLightness = 0.2,
+    double maxLightness = 0.8,
+  }) {
+    double lightness = hslColor.lightness;
+    if (lightness < minLightness) {
+      // Too dark
+      return hslColor.withLightness(minLightness);
+    } else if (lightness > maxLightness) {
+      // Too light
+      return hslColor.withLightness(maxLightness);
+    }
+    // Within range, return unchanged
+    return hslColor;
+  }
+
+  /// Returns a "dimmed" version of the provided color.
+  /// The dimFactor (between 0.0 and 1.0) indicates how much to reduce the
+  /// color's lightness.
+  static HSLColor dimColorHsl(HSLColor hslColor, {double dimFactor = 0.1}) {
     final newLightness = (hslColor.lightness - dimFactor).clamp(0.0, 1.0);
-    return hslColor.withLightness(newLightness).toColor();
+    return hslColor.withLightness(newLightness);
   }
 }

--- a/lib/screens/lyrics/lyrics_screen.dart
+++ b/lib/screens/lyrics/lyrics_screen.dart
@@ -1,4 +1,5 @@
 import 'package:boxify/app_core.dart';
+import 'package:boxify/helpers/color_helper.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
@@ -33,7 +34,8 @@ class LyricsScreen extends StatelessWidget {
           // but we should extract this color from the image directly (like in small_track_detail_screen.dart)
           // the value should probably be inherited from parents?
           child: LyricsWidget(
-              track: track, backgroundColor: track.backgroundColor),
+              track: track,
+              backgroundColor: HSLColor.fromColor(track.backgroundColor)),
         ),
       ],
     );
@@ -46,7 +48,7 @@ class LyricsWidget extends StatelessWidget {
       : super(key: key);
 
   final Track track;
-  final Color backgroundColor;
+  final HSLColor backgroundColor;
 
   @override
   Widget build(BuildContext context) {
@@ -66,7 +68,11 @@ class LyricsWidget extends StatelessWidget {
     return Container(
       // give it rounded corners
       decoration: BoxDecoration(
-          borderRadius: BorderRadius.circular(10), color: backgroundColor),
+        borderRadius: BorderRadius.circular(10),
+        color: ColorHelper.ensureWithinRangeHsl(backgroundColor,
+                minLightness: 0.35, maxLightness: 0.6)
+            .toColor(),
+      ),
 
       child: Padding(
         padding: padding,

--- a/lib/screens/player/player.dart
+++ b/lib/screens/player/player.dart
@@ -34,9 +34,10 @@ class Player extends StatelessWidget {
       } else {
         /// Get the [Track] from the player.audiosource that is currently playing,
         /// or the first track in the PlayerState.queue if no track is playing
-        Track track;
+        Track track = state.queue[index ?? 0];
 
-        track = state.queue[index ?? 0];
+        // Get current track's backgroundColor
+        final backgroundColor = state.backgroundColor;
 
         logger.d(
             'state.player.currentIndex on Player: ${state.player.currentIndex}');
@@ -58,7 +59,9 @@ class Player extends StatelessWidget {
                 : SmallPlayer(
                     imageUrl: imageUrl,
                     imageFilename: imageFilename,
-                    track: track);
+                    track: track,
+                    backgroundColor: backgroundColor,
+                  );
           },
         );
       }

--- a/lib/screens/player/widgets/small_player_skeleton.dart
+++ b/lib/screens/player/widgets/small_player_skeleton.dart
@@ -15,7 +15,10 @@ class SmallPlayerSkeleton extends StatelessWidget {
     return Container(
       decoration: BoxDecoration(
         borderRadius: BorderRadius.circular(8),
-        color: ColorHelper.dimColor(Core.appColor.primary, dimFactor: 0.25),
+        color: ColorHelper.dimColor(
+            ColorHelper.ensureWithinRange(Core.appColor.primary,
+                maxLightness: 0.7, minLightness: 0.5),
+            dimFactor: 0.25),
         boxShadow: const [
           BoxShadow(
             blurRadius: 2,

--- a/lib/screens/player/widgets/small_player_title_and_artist_widget.dart
+++ b/lib/screens/player/widgets/small_player_title_and_artist_widget.dart
@@ -1,7 +1,6 @@
 import 'dart:math';
 import 'package:boxify/app_core.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 
 /// Used in [SmallPlayer]
 class SmallPlayerTitleAndArtistWidget extends StatelessWidget {
@@ -16,10 +15,6 @@ class SmallPlayerTitleAndArtistWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final playerBloc = BlocProvider.of<PlayerBloc>(context);
-    final state = playerBloc.state;
-    final status = state.status;
-
     final imageSize = 50;
     final buttonSize = 44;
     final width = MediaQuery.of(context).size.width - (imageSize + buttonSize);

--- a/lib/screens/small_track_detail/small_track_detail_screen.dart
+++ b/lib/screens/small_track_detail/small_track_detail_screen.dart
@@ -16,17 +16,13 @@ class PlayerSmallTrackDetailScreen extends StatefulWidget {
 
 class _PlayerSmallTrackDetailScreenState<Track>
     extends State<PlayerSmallTrackDetailScreen> {
-  // Track backgroundColor, used for the gradient
-  Color _backgroundColor = Colors.grey;
-
   @override
   Widget build(BuildContext context) {
     return BlocBuilder<PlayerBloc, MyPlayerState>(
       builder: (context, state) {
-        final playerBlocState = context.read<PlayerBloc>().state;
+        final playerBloc = context.read<PlayerBloc>();
         final playlistBloc = context.read<PlaylistBloc>();
-        final track =
-            playerBlocState.queue[playerBlocState.player.currentIndex!];
+        final track = state.queue[state.player.currentIndex!];
 
         final enquedPlaylist = playlistBloc.state.enquedPlaylist;
 
@@ -49,7 +45,10 @@ class _PlayerSmallTrackDetailScreenState<Track>
                 begin: Alignment.topCenter,
                 end: Alignment.bottomCenter,
                 colors: [
-                  _backgroundColor,
+                  // Ensure the background color (extracted from track image) is neither too light nor too dark
+                  ColorHelper.ensureWithinRangeHsl(state.backgroundColor,
+                          minLightness: 0.25, maxLightness: 0.7)
+                      .toColor(),
                   Core.appColor.widgetBackgroundColor,
                 ],
               ),
@@ -80,14 +79,10 @@ class _PlayerSmallTrackDetailScreenState<Track>
                           // Make sure widget is mounted before setting state
                           // This may happen if the user closes the screen before the image is loaded
                           if (!mounted) return;
-                          setState(() {
-                            // Update the current background color every time a new image is loaded
-                            // Also ensure that the background isnt too light or too dark
-                            _backgroundColor = ColorHelper.ensureWithinRange(
-                                color,
-                                minLightness: 0.25,
-                                maxLightness: 0.7);
-                          });
+
+                          // Update track's backgroundColor
+                          playerBloc.add(UpdateTrackBackgroundColor(
+                              backgroundColor: HSLColor.fromColor(color)));
                         },
                       ),
                       const SizedBox(height: 20),
@@ -100,7 +95,7 @@ class _PlayerSmallTrackDetailScreenState<Track>
                       ),
                       const SizedBox(height: 10),
                       LyricsWidget(
-                          track: track, backgroundColor: _backgroundColor),
+                          track: track, backgroundColor: state.backgroundColor),
                     ],
                   ),
                 ),


### PR DESCRIPTION
This PR should greatly improve my previous implementation of #80 (*Dynamically extract track's background color from its cover image*).

# Improvements
The **main** upgrade is that the track background color is now in stored in the PlayerState, meaning that all widgets have access to the same color (instead of storing it individually). This grantees that the track color will always be consistent across the app.

**Concretely, this fixes:**
1. When a track does not have a cover image, the small player kept the color of the previous track, while the detailed track screen became grey. Now both will keep the color of the previous track:
![image](https://github.com/user-attachments/assets/38cd811a-dbfe-4abf-b806-f37670fa9947)

2. At startup, the player has the app's main color, but the track details screen is grey. They now both share the same color.

3. When opening the track details screen, the color flashes quickly from grey to the actual track color, which wasn't really noticeable on the emulators, but is very visible on my phone - and it didn't look great. This is also fixed, the color will match instantly.

# Other changes
I've made some adjustments to the color corrections, it should now fit much better with the UI globally:
| Before | Now |
|---|---|
| ![image](https://github.com/user-attachments/assets/91d893ec-acca-4fc2-b776-e2766667328e)| ![image](https://github.com/user-attachments/assets/b4a2f662-1821-49bd-9783-4fffc405552c)|
|![image](https://github.com/user-attachments/assets/0198b30a-61f5-4c90-a4a8-5eb30627f731)|![image](https://github.com/user-attachments/assets/26ca881e-bc5c-47eb-b6a3-ddb5e82689c2)|
| ![image](https://github.com/user-attachments/assets/cb943102-51fd-4bf6-9023-3577a6f872cf) | ![image](https://github.com/user-attachments/assets/45e88f7a-2b73-40a8-ba78-e6ed4a9a4573) |

The initial color (app's main color) was also very dimmed, it should now be corrected and display the correct color:
| Before | Now |
|---|---|
|![image](https://github.com/user-attachments/assets/7594dcc6-2905-4fcc-bc3c-c4068de709aa)|![image](https://github.com/user-attachments/assets/729bd690-b770-4374-99b9-f49914ea6bb4)|

# Details
I've done some performances optimizations by reducing significantly the amount of unnecessary conversions between `HSLColor` and `Color` objects when applying color correction.

And I've added a few comments for better maintainability.

---
The track color feature should now integrate much more nicely into the app. Hope this helps!