### PR TITLE
Track images now show up in search and in the liked songs playlist

### DIFF
--- a/lib/blocs/market/market_bloc.dart
+++ b/lib/blocs/market/market_bloc.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'package:boxify/app_core.dart';
+import 'package:boxify/services/bundles_manager.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:equatable/equatable.dart';
 
@@ -63,6 +64,9 @@ class MarketBloc extends Bloc<MarketEvent, MarketState> {
 
       counts = _userHelper.calculateCounts(event.user, allBundles);
     }
+
+    // Initialize the bundles manager
+    BundleManager().updateBundles(allBundles);
 
     final unpurchasedBundles = allBundles
         .where((bundle) => !event.user.bundleIds.contains(bundle.id))

--- a/lib/blocs/player/my_player_state.dart
+++ b/lib/blocs/player/my_player_state.dart
@@ -21,12 +21,17 @@ class MyPlayerState extends Equatable {
   final HSLColor backgroundColor;
   List<Track> queue;
 
+  /// Source of the current track being played (where is the track playing from?)
+  /// Examples: PLAYLIST, SEARCH or BUNDLE
+  final String source;
+
   MyPlayerState({
     required this.status,
     required this.failure,
     required this.player,
     required this.backgroundColor,
     required this.queue,
+    required this.source,
   });
 
   factory MyPlayerState.initial(
@@ -38,6 +43,7 @@ class MyPlayerState extends Equatable {
       player: player,
       backgroundColor: HSLColor.fromColor(Core.appColor.primary),
       queue: [],
+      source: 'INITIAL',
     );
   }
 
@@ -48,6 +54,7 @@ class MyPlayerState extends Equatable {
         player,
         backgroundColor,
         queue,
+        source,
       ];
 
   MyPlayerState copyWith({
@@ -57,6 +64,7 @@ class MyPlayerState extends Equatable {
     ConcatenatingAudioSource? audioSource,
     HSLColor? backgroundColor,
     List<Track>? queue,
+    String? source,
   }) {
     return MyPlayerState(
       status: status ?? this.status,
@@ -64,6 +72,7 @@ class MyPlayerState extends Equatable {
       player: player ?? this.player,
       backgroundColor: backgroundColor ?? this.backgroundColor,
       queue: queue ?? this.queue,
+      source: source ?? this.source,
     );
   }
 }

--- a/lib/blocs/player/player_bloc.dart
+++ b/lib/blocs/player/player_bloc.dart
@@ -127,7 +127,8 @@ class PlayerBloc extends Bloc<PlayerEvent, MyPlayerState> {
     Emitter<MyPlayerState> emit,
   ) async {
     logger.i('_onStartPlayback PlayerStatus.playPressed');
-    emit(state.copyWith(status: PlayerStatus.playPressed));
+    emit(
+        state.copyWith(status: PlayerStatus.playPressed, source: event.source));
 
     final trackIndexMapping = createTrackIndexMapping(event.tracks);
     final audioSourceIndex = trackIndexMapping[event.index];

--- a/lib/blocs/player/player_event.dart
+++ b/lib/blocs/player/player_event.dart
@@ -27,8 +27,9 @@ class Play extends PlayerEvent {
 class StartPlayback extends PlayerEvent {
   final int? index;
   final List<Track> tracks;
+  final String? source;
 
-  const StartPlayback({required this.index, required this.tracks});
+  const StartPlayback({required this.index, required this.tracks, this.source});
 
   @override
   List<Object?> get props => [tracks, index];

--- a/lib/blocs/playlist/playlist_bloc.dart
+++ b/lib/blocs/playlist/playlist_bloc.dart
@@ -39,6 +39,7 @@ class PlaylistBloc extends Bloc<PlaylistEvent, PlaylistState> {
     on<InitialPlaylistState>(_onInitialState);
     on<SetEditingPlaylist>(_onSetEditingPlaylist);
     on<SetEnqueuedPlaylist>(_onSetEnqueuedPlaylist);
+    on<ResetEnqueuedPlaylist>(_onResetEnqueuedPlaylist);
     on<LoadFollowedPlaylists>(_onLoadFollowedPlaylists);
     on<Load4And5StarPlaylists>(_onLoad4And5StarPlaylists);
     on<LoadAllSongsPlaylist>(_onLoadAllSongsPlaylist);
@@ -115,6 +116,18 @@ class PlaylistBloc extends Bloc<PlaylistEvent, PlaylistState> {
         ),
       );
     }
+  }
+
+  /// Reset the enqueued playlist to null
+  Future<void> _onResetEnqueuedPlaylist(
+    ResetEnqueuedPlaylist event,
+    Emitter<PlaylistState> emit,
+  ) async {
+    // enqueued playlist value can't be reset with copyWith, since
+    // providing a null value will not change the value of the state
+    final newState = state.copyWith(); // so we create a new state..
+    newState.enquedPlaylist = null; // ..and set the value to null manually
+    emit(newState);
   }
 
   /// Loads all the playlists asynchronously.

--- a/lib/blocs/playlist/playlist_event.dart
+++ b/lib/blocs/playlist/playlist_event.dart
@@ -35,6 +35,10 @@ class SetEnqueuedPlaylist extends PlaylistEvent {
   List<Object?> get props => [playlist];
 }
 
+class ResetEnqueuedPlaylist extends PlaylistEvent {
+  const ResetEnqueuedPlaylist();
+}
+
 class LoadNewReleasesPlaylist extends PlaylistEvent {
   final bool clearPlaylistsCache;
 

--- a/lib/helpers/get_image_widgets.dart
+++ b/lib/helpers/get_image_widgets.dart
@@ -57,17 +57,18 @@ String? assignPlaylistImageFilenameToTrack(Track track, Playlist? playlist) {
 /// then use the playlist imageUrl.
 /// For By The People playlist, never use the playlist image because we want to use the
 /// individual track images instead. They have the user's profileImageUrl.
-String? assignPlaylistImageUrlToTrack(Track track, Playlist? playlist) {
-  if (playlist == null) {
-    return null;
-  }
-  // if (playlist.id == Core.app.byThePeoplePlaylistId) {
-  //   return track.imageUrl;
-  // }
-  if (track.imageUrl != null &&
+String? assignPlaylistImageUrlToTrack(Track track, Playlist? playlist,
+    {Bundle? bundle}) {
+  if (bundle != null && bundle.image != null) {
+    // Return bundle image
+    return bundle.image;
+  } else if (track.imageUrl != null &&
       track.imageUrl != '' &&
       track.imageUrl != Core.app.defaultImageUrl) {
     return track.imageUrl;
+  } else if (playlist == null) {
+    // Track doesn't have an image and isn't in a bundle or a playlist
+    return null;
   } else if (playlist.imageUrl != null &&
       playlist.imageUrl != '' &&
       playlist.imageUrl != Core.app.defaultImageUrl) {

--- a/lib/helpers/get_image_widgets.dart
+++ b/lib/helpers/get_image_widgets.dart
@@ -1,4 +1,5 @@
 import 'package:boxify/app_core.dart';
+import 'package:boxify/services/bundles_manager.dart';
 import 'package:flutter/material.dart';
 
 const fireUrl = "https://www.dropbox.com/s/wfycymz8txb9zcp/fire.jpg?raw=1";
@@ -57,23 +58,31 @@ String? assignPlaylistImageFilenameToTrack(Track track, Playlist? playlist) {
 /// then use the playlist imageUrl.
 /// For By The People playlist, never use the playlist image because we want to use the
 /// individual track images instead. They have the user's profileImageUrl.
-String? assignPlaylistImageUrlToTrack(Track track, Playlist? playlist,
-    {Bundle? bundle}) {
-  if (bundle != null && bundle.image != null) {
-    // Return bundle image
-    return bundle.image;
-  } else if (track.imageUrl != null &&
+String? assignPlaylistImageUrlToTrack(Track track, Playlist? playlist) {
+  if (track.imageUrl != null &&
       track.imageUrl != '' &&
       track.imageUrl != Core.app.defaultImageUrl) {
     return track.imageUrl;
   } else if (playlist == null) {
-    // Track doesn't have an image and isn't in a bundle or a playlist
-    return null;
+    // Track doesn't have an image and isn't in a playlist
+    // Try returning bundle image
+    return assignBundleImageUrlToTrack(track);
   } else if (playlist.imageUrl != null &&
       playlist.imageUrl != '' &&
       playlist.imageUrl != Core.app.defaultImageUrl) {
     return playlist.imageUrl;
   } else {
-    return null;
+    // Track is in a playlist but doesn't have an image
+    // Try returning bundle image
+    return assignBundleImageUrlToTrack(track);
   }
+}
+
+/// Returns the imageUrl of the track's bundle.
+///
+/// If the track isn't part of a bundle or the bundle doesn't have any image, null will be returned.
+String? assignBundleImageUrlToTrack(Track track) {
+  final bundle = BundleManager().getBundle(track.bundleId);
+  if (bundle == null || bundle.image == null) return null;
+  return bundle.image;
 }

--- a/lib/helpers/track_mouse_row_helper.dart
+++ b/lib/helpers/track_mouse_row_helper.dart
@@ -485,6 +485,7 @@ class TrackMouseRowHelper {
           index: i,
           tracks: context.read<TrackBloc>().state.displayedTracks,
           playlist: playlistBloc.state.viewedPlaylist,
+          source: 'PLAYLIST',
         );
 
     if (!canPlay) {

--- a/lib/models/user_model.dart
+++ b/lib/models/user_model.dart
@@ -25,9 +25,10 @@ class User extends Equatable {
   final List<String> playlistIds;
   final List<dynamic> badges;
   final List<dynamic> purchases;
+
   /// The roles array determines what tracks a user can access in the basic app type.
   /// (Note: Roles are not used in the advanced app type)
-  /// 
+  ///
   /// Role-based access is implemented entirely through Firestore:
   /// 1. Users have a roles array in their Firestore document
   /// 2. Tracks have a role field in their Firestore document

--- a/lib/screens/library_panel/large_playlist_tile.dart
+++ b/lib/screens/library_panel/large_playlist_tile.dart
@@ -110,6 +110,7 @@ class LargePlaylistTile extends StatelessWidget {
         context.read<PlayerService>().handlePlay(
               tracks: tracks,
               playlist: playlist,
+              source: 'PLAYLIST',
             );
       },
       child: Container(

--- a/lib/screens/playlist/widgets/playlist_touch_screen.dart
+++ b/lib/screens/playlist/widgets/playlist_touch_screen.dart
@@ -115,6 +115,7 @@ class _PlaylistTouchScreenState extends State<PlaylistTouchScreen> {
                                                 tracks: state.displayedTracks,
                                                 index: index,
                                                 playlist: playlist,
+                                                source: 'PLAYLIST',
                                               );
                                           if (!canPlay) {
                                             showTrackSnack(

--- a/lib/screens/playlist/widgets/track_touch_row.dart
+++ b/lib/screens/playlist/widgets/track_touch_row.dart
@@ -15,6 +15,10 @@ class TrackTouchRow extends StatelessWidget {
   final bool showAddButton;
   final bool canLongPress;
 
+  /// Bundle the track is part of. Should only be provided when outside of a playlist
+  /// when playing directly from a bundle (search included).
+  final Bundle? bundle;
+
   TrackTouchRow({
     required this.i,
     required this.indexWithinPlayableTracks,
@@ -26,6 +30,7 @@ class TrackTouchRow extends StatelessWidget {
     this.showBundleArtistText = true,
     this.showAddButton = false,
     this.canLongPress = true,
+    this.bundle,
   });
 
   @override
@@ -41,7 +46,8 @@ class TrackTouchRow extends StatelessWidget {
         return ListTile(
           tileColor: Core.appColor.widgetBackgroundColor,
           leading: imageOrIcon(
-            imageUrl: assignPlaylistImageUrlToTrack(track, playlist),
+            imageUrl:
+                assignPlaylistImageUrlToTrack(track, playlist, bundle: bundle),
             filename: assignPlaylistImageFilenameToTrack(track, playlist),
             height: Core.app.smallRowImageSize,
             width: Core.app.smallRowImageSize,

--- a/lib/screens/playlist/widgets/track_touch_row.dart
+++ b/lib/screens/playlist/widgets/track_touch_row.dart
@@ -15,10 +15,6 @@ class TrackTouchRow extends StatelessWidget {
   final bool showAddButton;
   final bool canLongPress;
 
-  /// Bundle the track is part of. Should only be provided when outside of a playlist
-  /// when playing directly from a bundle (search included).
-  final Bundle? bundle;
-
   TrackTouchRow({
     required this.i,
     required this.indexWithinPlayableTracks,
@@ -30,7 +26,6 @@ class TrackTouchRow extends StatelessWidget {
     this.showBundleArtistText = true,
     this.showAddButton = false,
     this.canLongPress = true,
-    this.bundle,
   });
 
   @override
@@ -46,8 +41,7 @@ class TrackTouchRow extends StatelessWidget {
         return ListTile(
           tileColor: Core.appColor.widgetBackgroundColor,
           leading: imageOrIcon(
-            imageUrl:
-                assignPlaylistImageUrlToTrack(track, playlist, bundle: bundle),
+            imageUrl: assignPlaylistImageUrlToTrack(track, playlist),
             filename: assignPlaylistImageFilenameToTrack(track, playlist),
             height: Core.app.smallRowImageSize,
             width: Core.app.smallRowImageSize,

--- a/lib/screens/search_music/widgets/small_track_search_results.dart
+++ b/lib/screens/search_music/widgets/small_track_search_results.dart
@@ -1,5 +1,6 @@
 import 'package:boxify/app_core.dart';
 import 'package:boxify/screens/playlist/widgets/track_touch_row_skeleton.dart';
+import 'package:boxify/services/bundles_manager.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:collection/collection.dart';
@@ -27,14 +28,6 @@ class SmallTrackSearchResults extends StatelessWidget {
     var indexWithinPlayableTracks = -1;
 
     Widget buildTrackRow(BuildContext context, int i, Track track) {
-      // Get track's bundle, if any.
-      // TODO (important) this isn't efficient, we should create a map with a O(1) lookup complexity
-      // the current code uses a O(n) lookup. for now this is fine since there are only a few bundles.
-      final bundle = track.bundleId != null
-          ? marketBloc.state.allBundles
-              .firstWhereOrNull((bundle) => bundle.id == track.bundleId)
-          : null;
-
       if (track.available == true) {
         indexWithinPlayableTracks++;
       }
@@ -55,7 +48,6 @@ class SmallTrackSearchResults extends StatelessWidget {
         showOverflowScreen: screenType == SearchResultType.searchScreen,
         showAddButton: screenType == SearchResultType.addToPlaylist,
         canLongPress: screenType == SearchResultType.searchScreen,
-        bundle: bundle,
       );
     }
 
@@ -102,6 +94,7 @@ class SmallTrackSearchResults extends StatelessWidget {
     final canPlay = context.read<PlayerService>().handlePlay(
           index: i,
           tracks: searchBloc.state.searchResultsTracks,
+          source: 'SEARCH',
         );
     if (!canPlay) {
       showTrackSnack(context, track.bundleName ?? '?');

--- a/lib/screens/search_music/widgets/small_track_search_results.dart
+++ b/lib/screens/search_music/widgets/small_track_search_results.dart
@@ -2,6 +2,7 @@ import 'package:boxify/app_core.dart';
 import 'package:boxify/screens/playlist/widgets/track_touch_row_skeleton.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:collection/collection.dart';
 
 /// Returns a [ListView] of [TrackTouchRow]s. Used by [SmallSearchScreen] and [PlaylistTouchScreen].
 /// On the Small Search Screen, each [TrackTouchRow] should have an [overflowScreen].
@@ -21,13 +22,23 @@ class SmallTrackSearchResults extends StatelessWidget {
   Widget build(BuildContext context) {
     final searchBloc = context.read<SearchBloc>();
     final playlistBloc = context.read<PlaylistBloc>();
+    final marketBloc = context.read<MarketBloc>(); // used to get bundle details
     final trackBloc = context.read<TrackBloc>();
     var indexWithinPlayableTracks = -1;
 
     Widget buildTrackRow(BuildContext context, int i, Track track) {
+      // Get track's bundle, if any.
+      // TODO (important) this isn't efficient, we should create a map with a O(1) lookup complexity
+      // the current code uses a O(n) lookup. for now this is fine since there are only a few bundles.
+      final bundle = track.bundleId != null
+          ? marketBloc.state.allBundles
+              .firstWhereOrNull((bundle) => bundle.id == track.bundleId)
+          : null;
+
       if (track.available == true) {
         indexWithinPlayableTracks++;
       }
+
       return TrackTouchRow(
         i: i,
         indexWithinPlayableTracks: indexWithinPlayableTracks,
@@ -44,6 +55,7 @@ class SmallTrackSearchResults extends StatelessWidget {
         showOverflowScreen: screenType == SearchResultType.searchScreen,
         showAddButton: screenType == SearchResultType.addToPlaylist,
         canLongPress: screenType == SearchResultType.searchScreen,
+        bundle: bundle,
       );
     }
 

--- a/lib/screens/small_track_detail/small_track_detail_screen.dart
+++ b/lib/screens/small_track_detail/small_track_detail_screen.dart
@@ -58,10 +58,9 @@ class _PlayerSmallTrackDetailScreenState<Track>
               children: [
                 // const SizedBox(height: 20),
                 SmallDetailTopListTile(
-                  playlist: playlistBloc.state.enquedPlaylist,
-                  track: track,
-                  source: 'PLAYLIST',
-                ),
+                    playlist: playlistBloc.state.enquedPlaylist,
+                    track: track,
+                    source: state.source),
                 const SizedBox(height: 10),
 
                 /// This is the actual up front image for the track

--- a/lib/screens/track/widgets/small_track_screen.dart
+++ b/lib/screens/track/widgets/small_track_screen.dart
@@ -43,9 +43,10 @@ class _SmallTrackScreenState extends State<SmallTrackScreen> {
 
       // if (width < Core.app.largeSmallBreakpoint) {
       final canPlay = context.read<PlayerService>().handlePlay(
-        index: 0,
-        tracks: [track],
-      );
+            index: 0,
+            tracks: [track],
+            source: 'PLAYLIST',
+          );
       if (!canPlay) {
         showTrackSnack(context, track.bundleName!);
       }

--- a/lib/services/bundles_manager.dart
+++ b/lib/services/bundles_manager.dart
@@ -1,0 +1,29 @@
+import 'package:boxify/app_core.dart';
+
+/// Stores and manages the list of bundles available in the app.
+class BundleManager {
+  // Singleton instance (for static access across the app)
+  static final BundleManager _instance = BundleManager._internal();
+  factory BundleManager() => _instance;
+  BundleManager._internal();
+
+  final Map<String, Bundle> _bundles = {};
+
+  // Public accessor for bundles
+  Map<String, Bundle> get bundles => Map.unmodifiable(_bundles);
+
+  // Update bundle list with new data. Will clear the existing data.
+  Future<void> updateBundles(List<Bundle> bundles) async {
+    _bundles.clear();
+    for (var bundle in bundles) {
+      if (bundle.id != null) {
+        _bundles[bundle.id!] = bundle;
+      }
+    }
+  }
+
+  // Get bundle by ID (O(1) access)
+  Bundle? getBundle(String id) {
+    return _bundles[id];
+  }
+}

--- a/lib/services/bundles_manager.dart
+++ b/lib/services/bundles_manager.dart
@@ -22,8 +22,11 @@ class BundleManager {
     }
   }
 
-  // Get bundle by ID (O(1) access)
-  Bundle? getBundle(String id) {
-    return _bundles[id];
+  // Get bundle by ID
+  Bundle? getBundle(String? id) {
+    if (_bundles.containsKey(id)) {
+      return _bundles[id];
+    }
+    return null;
   }
 }

--- a/lib/services/player_service.dart
+++ b/lib/services/player_service.dart
@@ -55,10 +55,12 @@ class PlayerService {
   /// - `selectTrack` ([bool]): whether the track should be selected
   /// - `updateQueue` ([bool]): whether the player should be reinitialized
   /// - `index` ([int]): the index of the track to be played
+  /// - `source` ([String]): the source of the track (where it's being played from - e.g. 'PLAYLIST', 'SEARCH', etc.)
   bool handlePlay({
     List<Track>? tracks,
     Playlist? playlist,
     int? index,
+    required String source,
   }) {
     /// If you're simply toggling the play button for the current track
     if (tracks == null) {
@@ -91,14 +93,20 @@ class PlayerService {
         }
       }
 
-      /// If this function was called with as a request to play a specific playlist,
-      if (playlist != null) {
-        _playlistBloc.add(SetEnqueuedPlaylist(playlist: playlist));
+      // Enqueue playlist if it's not already enqueued
+      // Note: playlist can be null (e.g. when playing from search results), will reset the queue
+      if (_playlistBloc.state.enquedPlaylist != playlist) {
+        if (playlist == null) {
+          _playlistBloc.add(ResetEnqueuedPlaylist());
+        } else {
+          _playlistBloc.add(SetEnqueuedPlaylist(playlist: playlist));
+        }
       }
 
       _playerBloc.add(StartPlayback(
         tracks: tracks,
         index: index,
+        source: source,
       ));
 
       return true;

--- a/lib/widgets/buttons.dart
+++ b/lib/widgets/buttons.dart
@@ -266,7 +266,7 @@ class LogOutButton extends StatelessWidget {
 
         // Reset player state before logging out
         context.read<PlayerBloc>().add(PlayerReset());
-        
+
         context.read<AuthBloc>().add(AuthLogoutRequested());
 
         GoRouter.of(context).go(
@@ -544,6 +544,7 @@ class MyPlayButton extends StatelessWidget {
                 tracks: context.read<TrackBloc>().state.displayedTracks,
                 playlist: context.read<PlaylistBloc>().state.viewedPlaylist,
                 index: index,
+                source: 'PLAYLIST',
               );
         },
         child: Icon(
@@ -599,9 +600,10 @@ class PlayButton extends StatelessWidget {
               iconSize: size,
               onPressed: () {
                 context.read<PlayerService>().handlePlay(
-                    // tracks: context.read<TrackBloc>().state.displayedTracks,
-                    // playlist:
-                    //     context.read<PlaylistBloc>().state.viewedPlaylist,
+                      // tracks: context.read<TrackBloc>().state.displayedTracks,
+                      // playlist:
+                      //     context.read<PlaylistBloc>().state.viewedPlaylist,
+                      source: 'PLAYLIST',
                     );
               });
         } else if (processingState != ProcessingState.completed) {
@@ -769,6 +771,7 @@ class _PlayButtonInCircleState extends State<PlayButtonInCircle> {
     final canPlay = context.read<PlayerService>().handlePlay(
           tracks: tracks,
           playlist: widget.playlist,
+          source: 'PLAYLIST',
         );
 
     if (!canPlay && Core.app.type == AppType.advanced) {

--- a/lib/widgets/modal_bottom_sheets.dart
+++ b/lib/widgets/modal_bottom_sheets.dart
@@ -124,9 +124,10 @@ void showTrackOverflowMenu(
     required Track track,
     Playlist? playlist,
     int? index}) {
-  String? imageFilename = track.imageFilename;
-  if (playlist != null) {
-    imageFilename = assignPlaylistImageFilenameToTrack(track, playlist);
+  String? imageUrl = assignPlaylistImageUrlToTrack(track, playlist);
+  String? imageFilename = assignPlaylistImageFilenameToTrack(track, playlist);
+  if (imageUrl == null && imageFilename == null) {
+    imageFilename = Core.app.placeHolderImageFilename;
   }
   showModalBottomSheet(
     context: context,
@@ -135,7 +136,7 @@ void showTrackOverflowMenu(
         mainAxisSize: MainAxisSize.min,
         children: [
           imageOrIcon(
-              imageUrl: track.imageUrl,
+              imageUrl: imageUrl,
               filename: imageFilename,
               height: 120,
               width: 120),


### PR DESCRIPTION
This PR addresses issue #118.

here are the changes brought by this pull request:

# Track images are now displayed:
Since the tracks were outside playlists, no image was assigned to them. With this change, the `assignImage` function will now work outside of playlists by directly using the track image or by defaulting to its bundle image.

![image](https://github.com/user-attachments/assets/8a422a8d-aa84-4b28-8165-441745727e70)

..and this also resolves an issue that wasn't mentioned in #118, but track images are now correctly shown in the "Liked Songs' playlist:

![image](https://github.com/user-attachments/assets/abc96162-821b-4885-96de-4574eeb39921)

# Custom audio sources can now be displayed:
When playing from search results, the detailed screen was displaying "PLAYING FROM PLAYLIST" with the name of the last enqueued playlist as a subtitle. It will now instead show "PLAYING FROM SEARCH":

![image](https://github.com/user-attachments/assets/688c1359-9fa1-40f9-8cc0-cff04c398279)

This value is stored in the `PlayerState` and must be provided when calling the `handlePlay` function that starts audio playback. This will probably come handy for future features (..playing from bundles?).

The enqueued playlist can also now be reset with this new `PlayerEvent` called `ResetEnqueuedPlaylist`.

# Other small changes:
These changes have also been appropriately applied to the "three dot"/long press menu on tracks from search results. It will display the track image, and if no image can be found, it will now fallback to the local placeholder instead of a remote image for better performances.

![image](https://github.com/user-attachments/assets/9f35172a-b379-4810-a5b9-773cdcc2578f)

And there was a small unintended side effect.. but it's a good one: these changes have also fixed the initial track image that wasn't getting displayed at startup.

![image](https://github.com/user-attachments/assets/823a7e14-93ef-458a-a7ed-9d7533c1dde9)

# New "bundles manager":
I've added a new bundles manager to map all bundles to their IDs so each track can access its bundle data (like the image) in constant O(1) time instead of iterating over the bundle list each time. I will try to clean and remove other bundles list since they're redundant, and will centralize everything in this new efficient manager.

Bundle data can be accessed with:
```dart
BundleManager().getBundle(bundleId);
```
---

Let me know if there are any issues or questions regarding this PR!