### PR TITLE
handle "PLAYING FROM" translations

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -152,5 +152,9 @@
     "actionEditLibrary": "manage your library",
     "actionBuyBundles": "buy bundles",
     "logInOrSignUp": "LOG IN OR SIGN UP",
-    "notNow": "NOT NOW"
+    "notNow": "NOT NOW",
+    "playingFromSource": "PLAYING FROM {sourceName}",
+    "playlistSourceName": "PLAYLIST",
+    "searchSourceName": "SEARCH",
+    "initialSourceName": "INITIAL"
 }

--- a/assets/translations/fr.json
+++ b/assets/translations/fr.json
@@ -156,5 +156,9 @@
     "actionEditLibrary": "gérer votre bibliothèque",
     "actionBuyBundles": "acheter des packs",
     "logInOrSignUp": "SE CONNECTER OU S'INSCRIRE",
-    "notNow": "PAS MAINTENANT"
+    "notNow": "PAS MAINTENANT",
+    "playingFromSource": "LECTURE DEPUIS {sourceName}",
+    "playlistSourceName": "PLAYLIST",
+    "searchSourceName": "RECHERCHE",
+    "initialSourceName": "INITIAL"
 }

--- a/lib/blocs/player/my_player_state.dart
+++ b/lib/blocs/player/my_player_state.dart
@@ -12,6 +12,13 @@ enum PlayerStatus {
   error, // When an error occurs within the player (e.g., loading or playback fails).
 }
 
+enum PlayerSource {
+  initial, // When the player is first created or reset.
+  playlist, // playing from a playlist
+  search, // playing from a search result
+  bundle, // playing from a bundle
+}
+
 class MyPlayerState extends Equatable {
   final PlayerStatus status;
   final Failure failure;
@@ -23,7 +30,7 @@ class MyPlayerState extends Equatable {
 
   /// Source of the current track being played (where is the track playing from?)
   /// Examples: PLAYLIST, SEARCH or BUNDLE
-  final String source;
+  final PlayerSource source;
 
   MyPlayerState({
     required this.status,
@@ -43,7 +50,7 @@ class MyPlayerState extends Equatable {
       player: player,
       backgroundColor: HSLColor.fromColor(Core.appColor.primary),
       queue: [],
-      source: 'INITIAL',
+      source: PlayerSource.initial,
     );
   }
 
@@ -64,7 +71,7 @@ class MyPlayerState extends Equatable {
     ConcatenatingAudioSource? audioSource,
     HSLColor? backgroundColor,
     List<Track>? queue,
-    String? source,
+    PlayerSource? source,
   }) {
     return MyPlayerState(
       status: status ?? this.status,

--- a/lib/blocs/player/player_event.dart
+++ b/lib/blocs/player/player_event.dart
@@ -27,7 +27,7 @@ class Play extends PlayerEvent {
 class StartPlayback extends PlayerEvent {
   final int? index;
   final List<Track> tracks;
-  final String? source;
+  final PlayerSource? source;
 
   const StartPlayback({required this.index, required this.tracks, this.source});
 

--- a/lib/helpers/get_image_widgets.dart
+++ b/lib/helpers/get_image_widgets.dart
@@ -1,29 +1,5 @@
 import 'package:boxify/app_core.dart';
 import 'package:boxify/services/bundles_manager.dart';
-import 'package:flutter/material.dart';
-
-const fireUrl = "https://www.dropbox.com/s/wfycymz8txb9zcp/fire.jpg?raw=1";
-const summerUrl = fireUrl;
-const ramsayUrl =
-    "https://www.dropbox.com/s/4labks7ga1ymswb/494px-Hugh_Ramsay_-_The_four_seasons_-_Google_Art_Project.jpg?raw=1";
-const springUrl = 'https://www.dropbox.com/s/ncahf99tx3fn5ud/unnamed.jpg?raw=1';
-const autumDancersUrls =
-    'https://www.dropbox.com/s/j0igjm7f6negshq/Evgh_WaWgAAYYqt.jpg?raw=1';
-const autumnUrl = 'https://www.dropbox.com/s/dzxu01syuvhbk1y/autumn.jpg?raw=1';
-const winterUrl =
-    'https://www.dropbox.com/s/zwvi42bhcjx08gr/saint-man-white-robe-looking-sadly-camera-upset-humanity-mistakes-saint-man-white-robe-looking-sadly-camera-upset-157312502.jpg?raw=1';
-
-Image rcImage =
-    Image.asset('images/boxify.jpg', height: 60, width: 60, fit: BoxFit.cover);
-Image rcImage132 = Image.asset(
-  'images/boxify.png',
-  height: 132,
-  width: 132,
-  fit: BoxFit.cover,
-);
-
-Image funkoImage =
-    Image.asset('images/funko.jpg', height: 60, width: 60, fit: BoxFit.cover);
 
 /// Returns the imageFilename for the track from the playlist if any.
 ///

--- a/lib/helpers/track_mouse_row_helper.dart
+++ b/lib/helpers/track_mouse_row_helper.dart
@@ -485,7 +485,7 @@ class TrackMouseRowHelper {
           index: i,
           tracks: context.read<TrackBloc>().state.displayedTracks,
           playlist: playlistBloc.state.viewedPlaylist,
-          source: 'PLAYLIST',
+          source: PlayerSource.playlist,
         );
 
     if (!canPlay) {

--- a/lib/screens/library_panel/large_playlist_tile.dart
+++ b/lib/screens/library_panel/large_playlist_tile.dart
@@ -110,7 +110,7 @@ class LargePlaylistTile extends StatelessWidget {
         context.read<PlayerService>().handlePlay(
               tracks: tracks,
               playlist: playlist,
-              source: 'PLAYLIST',
+              source: PlayerSource.playlist,
             );
       },
       child: Container(

--- a/lib/screens/playlist/widgets/playlist_touch_screen.dart
+++ b/lib/screens/playlist/widgets/playlist_touch_screen.dart
@@ -115,7 +115,7 @@ class _PlaylistTouchScreenState extends State<PlaylistTouchScreen> {
                                                 tracks: state.displayedTracks,
                                                 index: index,
                                                 playlist: playlist,
-                                                source: 'PLAYLIST',
+                                                source: PlayerSource.playlist,
                                               );
                                           if (!canPlay) {
                                             showTrackSnack(

--- a/lib/screens/search_music/widgets/small_track_search_results.dart
+++ b/lib/screens/search_music/widgets/small_track_search_results.dart
@@ -94,7 +94,7 @@ class SmallTrackSearchResults extends StatelessWidget {
     final canPlay = context.read<PlayerService>().handlePlay(
           index: i,
           tracks: searchBloc.state.searchResultsTracks,
-          source: 'SEARCH',
+          source: PlayerSource.search,
         );
     if (!canPlay) {
       showTrackSnack(context, track.bundleName ?? '?');

--- a/lib/screens/small_track_detail/widgets/top_list_tile.dart
+++ b/lib/screens/small_track_detail/widgets/top_list_tile.dart
@@ -1,6 +1,5 @@
 import 'package:boxify/app_core.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
 
 /// A widget representing a [ListTile] particularly for showing playlist.
@@ -8,20 +7,21 @@ import 'package:go_router/go_router.dart';
 /// It includes a back IconButton as leading, a text 'PLAYING FROM PLAYLIST' as
 /// title and playlist's name as subtitle.
 class SmallDetailTopListTile extends StatelessWidget {
-  final String? source;
+  final PlayerSource source;
   final Track track;
   final Playlist? playlist;
 
   const SmallDetailTopListTile({
     super.key,
-    this.source = 'UNKNOWN',
+    required this.source,
     required this.track,
     this.playlist,
   });
 
   @override
   Widget build(BuildContext context) {
-    final title = 'PLAYING FROM $source';
+    final title = 'playingFromSource'
+        .translate(namedArgs: {'sourceName': source.name}).toUpperCase();
     return ListTile(
       leading: IconButton(
         onPressed: () {

--- a/lib/screens/track/widgets/small_track_screen.dart
+++ b/lib/screens/track/widgets/small_track_screen.dart
@@ -42,11 +42,9 @@ class _SmallTrackScreenState extends State<SmallTrackScreen> {
       // trackBloc.add(SetDisplayedTracksWithTracks(tracks: [track]));
 
       // if (width < Core.app.largeSmallBreakpoint) {
-      final canPlay = context.read<PlayerService>().handlePlay(
-            index: 0,
-            tracks: [track],
-            source: 'PLAYLIST',
-          );
+      final canPlay = context
+          .read<PlayerService>()
+          .handlePlay(index: 0, tracks: [track], source: PlayerSource.playlist);
       if (!canPlay) {
         showTrackSnack(context, track.bundleName!);
       }

--- a/lib/services/bundles_manager.dart
+++ b/lib/services/bundles_manager.dart
@@ -12,6 +12,9 @@ class BundleManager {
   // Public accessor for bundles
   Map<String, Bundle> get bundles => Map.unmodifiable(_bundles);
 
+  // List of all bundles
+  List<Bundle> get bundlesList => _bundles.values.toList();
+
   // Update bundle list with new data. Will clear the existing data.
   Future<void> updateBundles(List<Bundle> bundles) async {
     _bundles.clear();

--- a/lib/services/player_service.dart
+++ b/lib/services/player_service.dart
@@ -60,7 +60,7 @@ class PlayerService {
     List<Track>? tracks,
     Playlist? playlist,
     int? index,
-    required String source,
+    required PlayerSource source,
   }) {
     /// If you're simply toggling the play button for the current track
     if (tracks == null) {

--- a/lib/widgets/buttons.dart
+++ b/lib/widgets/buttons.dart
@@ -544,7 +544,7 @@ class MyPlayButton extends StatelessWidget {
                 tracks: context.read<TrackBloc>().state.displayedTracks,
                 playlist: context.read<PlaylistBloc>().state.viewedPlaylist,
                 index: index,
-                source: 'PLAYLIST',
+                source: PlayerSource.playlist,
               );
         },
         child: Icon(
@@ -603,7 +603,7 @@ class PlayButton extends StatelessWidget {
                       // tracks: context.read<TrackBloc>().state.displayedTracks,
                       // playlist:
                       //     context.read<PlaylistBloc>().state.viewedPlaylist,
-                      source: 'PLAYLIST',
+                      source: PlayerSource.playlist,
                     );
               });
         } else if (processingState != ProcessingState.completed) {
@@ -771,7 +771,7 @@ class _PlayButtonInCircleState extends State<PlayButtonInCircle> {
     final canPlay = context.read<PlayerService>().handlePlay(
           tracks: tracks,
           playlist: widget.playlist,
-          source: 'PLAYLIST',
+          source: PlayerSource.playlist,
         );
 
     if (!canPlay && Core.app.type == AppType.advanced) {

--- a/lib/widgets/popup_menu_actions.dart
+++ b/lib/widgets/popup_menu_actions.dart
@@ -67,7 +67,7 @@ class PopupMenuActions {
         // if (deletePlaylist == true)
         if (removeTrackFromPlaylist == true)
           PopupMenuBuilder.buildRemoveTrackFromPlaylistPopupMenuItem(
-              context, playlist!, 0),
+              context, playlist, 0),
         // if (stopFollowing == true)
       ],
       elevation: 8,
@@ -173,7 +173,7 @@ class PopupMenuActions {
     final playlists = context.read<PlaylistBloc>().state.followedPlaylists;
     final playlistIds = playlists.map((playlist) => playlist.id).toList();
 
-    final isAnonymous = context.read<UserBloc>().state.user.id == '';
+    final userState = context.read<UserBloc>().state;
 
     playlistIds.contains(playlist.id)
         ? await showMenu(

--- a/lib/widgets/tiles.dart
+++ b/lib/widgets/tiles.dart
@@ -18,7 +18,7 @@ class AddTrackToPlaylistTile extends StatelessWidget {
   Widget build(BuildContext context) {
     return ListTile(
       onTap: () {
-        logger.i('Add to playlist tile tapped');
+        final userState = context.read<UserBloc>().state;
 
         // Ensure user is logged in
         if (UserHelper.isLoggedInOrReroute(userState, context,
@@ -31,12 +31,8 @@ class AddTrackToPlaylistTile extends StatelessWidget {
             context.pop();
           }
 
-        // If you're on the small track detail screen, pop it
-        if (context.canPop()) {
-          context.pop();
+          context.push('/smallAddToPlaylist');
         }
-
-        context.push('/smallAddToPlaylist');
       },
       leading: const Icon(
         Icons.add,


### PR DESCRIPTION
## Handle "PLAYING FROM" translations
The "PLAYING FROM {source}" is now handled in translations, with each `source` having its own translation string.
Because the source isn't directly displayed in the UI anymore, I've converted it to an `enum`.

![image](https://github.com/user-attachments/assets/21240657-a799-4e16-a44b-1c9e39e00621)
```json
"playingFromSource": "PLAYING FROM {sourceName}",
"playlistSourceName": "PLAYLIST",
"searchSourceName": "SEARCH",
"initialSourceName": "INITIAL"
 ```

## Remove unused images/URLs
As suggested by Rivers, I've removed a bunch of unused image URLs, as well as some asset loads that weren't being used.

## Minor fixes
I've fixed a few merging issues from PR #138, I'm not sure what happened but some code has been removed when the merge occured, so I've added it back.