### PR TITLE
Shorten profile load time (new BundleManager implementation) 

### DIFF
--- a/lib/blocs/artist/artist_state.dart
+++ b/lib/blocs/artist/artist_state.dart
@@ -14,7 +14,6 @@ class ArtistState extends Equatable {
   final User user;
   final User viewer;
   final List<Bundle> bundles;
-  final List<Bundle> allBundles;
   final List<MyBadge> allBadges;
   final List<Playlist> userPlaylists;
   final List<MyBadge> badges;
@@ -35,7 +34,6 @@ class ArtistState extends Equatable {
     required this.user,
     required this.viewer,
     required this.bundles,
-    required this.allBundles,
     required this.allBadges,
     required this.userPlaylists,
     required this.badges,
@@ -58,7 +56,6 @@ class ArtistState extends Equatable {
       user: User.empty,
       viewer: User.empty,
       bundles: [],
-      allBundles: [],
       allBadges: [],
       userPlaylists: [],
       badges: [],
@@ -82,7 +79,6 @@ class ArtistState extends Equatable {
         user,
         viewer,
         bundles,
-        allBundles,
         allBadges,
         userPlaylists,
         badges,
@@ -105,7 +101,6 @@ class ArtistState extends Equatable {
     User? viewer,
     List<Bundle>? bundles,
     List<MyBadge>? badges,
-    List<Bundle>? allBundles,
     List<MyBadge>? allBadges,
     List<Playlist>? userPlaylists,
     bool? isCurrentUser,
@@ -125,7 +120,6 @@ class ArtistState extends Equatable {
       user: user ?? this.user,
       viewer: viewer ?? this.viewer,
       bundles: bundles ?? this.bundles,
-      allBundles: allBundles ?? this.allBundles,
       allBadges: allBadges ?? this.allBadges,
       userPlaylists: userPlaylists ?? this.userPlaylists,
       badges: badges ?? this.badges,

--- a/lib/blocs/market/market_bloc.dart
+++ b/lib/blocs/market/market_bloc.dart
@@ -67,6 +67,7 @@ class MarketBloc extends Bloc<MarketEvent, MarketState> {
 
     // Initialize the bundles manager
     BundleManager().updateBundles(allBundles);
+    BundleManager().setOwnedBundleIds(event.user.bundleIds);
 
     final unpurchasedBundles = allBundles
         .where((bundle) => !event.user.bundleIds.contains(bundle.id))
@@ -78,7 +79,6 @@ class MarketBloc extends Bloc<MarketEvent, MarketState> {
       trackCount: counts[1],
       userBundleCount: counts[2],
       userTrackCount: counts[3],
-      allBundles: allBundles,
       unpurchasedBundles: unpurchasedBundles,
     ));
     // final end = DateTime.now();
@@ -94,43 +94,40 @@ class MarketBloc extends Bloc<MarketEvent, MarketState> {
 
       // Update the user bundleIds in firestore
       _userRepository.addRemoveUserBundles(
-        bundleId: event.id!,
+        bundleId: event.id,
         user: event.user,
         switchOff: false,
       );
 
+      // Add new bundleId to the user's owned bundleIds
+      final newOwnedBundleIds = List<String>.from(event.user.bundleIds);
+      newOwnedBundleIds.add(event.id);
+
       // Create a copy of the event's user with the updated bundleIds
       final updatedUser = event.user.copyWith(
-        bundleIds: event.user.bundleIds..add(event.id!),
+        bundleIds: newOwnedBundleIds,
       );
 
-      // Create a new list for allBundles with the updated isOwned flag
-      final updatedAllBundles = state.allBundles.map((Bundle bundle) {
-        if (updatedUser.bundleIds.contains(bundle.id)) {
-          return bundle.copyWith(isOwned: true);
-        }
-        return bundle;
-      }).toList();
+      // Update the BundleManager with the new bundleIds
+      BundleManager().setOwnedBundleIds(updatedUser.bundleIds);
+
+      // Get all bundles from the BundleManager
+      final allBundles = BundleManager().bundlesList;
 
       // Email the bundle to the user
-      final purchasedBundle =
-          state.allBundles.firstWhere((bundle) => bundle.id == event.id);
+      final purchasedBundle = BundleManager().getBundle(event.id);
       _bundleRepository.emailBundleAndSavePurchaseToFirestore(
-          event.user, purchasedBundle);
+          event.user, purchasedBundle!);
 
       // Remove the purchased bundle from the available market bundles
-      final unpurchasedBundles = state.allBundles
+      final unpurchasedBundles = allBundles
           .where((bundle) => !updatedUser.bundleIds.contains(bundle.id))
           .toList();
-
-      // todo: update the user
-      // todo: update the tracks
 
       emit(
         state.copyWith(
           unpurchasedBundles: unpurchasedBundles,
           purchasedBundle: purchasedBundle,
-          allBundles: updatedAllBundles,
           status: MarketStatus.bundlePurchased,
         ),
       );

--- a/lib/blocs/market/market_event.dart
+++ b/lib/blocs/market/market_event.dart
@@ -17,7 +17,7 @@ class LoadMarket extends MarketEvent {
 }
 
 class PurchaseBundle extends MarketEvent {
-  final String? id;
+  final String id;
   final User user;
   const PurchaseBundle({required this.id, required this.user});
 

--- a/lib/blocs/market/market_state.dart
+++ b/lib/blocs/market/market_state.dart
@@ -15,7 +15,6 @@ class MarketState extends Equatable {
   final MarketStatus status;
   final Failure failure;
 
-  List<Bundle> allBundles;
   List<Bundle> unpurchasedBundles;
   final int trackCount;
   final int userTrackCount;
@@ -26,7 +25,6 @@ class MarketState extends Equatable {
   MarketState({
     required this.status,
     required this.failure,
-    required this.allBundles,
     required this.unpurchasedBundles,
     required this.trackCount,
     required this.userTrackCount,
@@ -39,7 +37,6 @@ class MarketState extends Equatable {
     return MarketState(
       status: MarketStatus.initial,
       failure: const Failure(),
-      allBundles: const [],
       unpurchasedBundles: const [],
       trackCount: 0,
       userTrackCount: 0,
@@ -55,7 +52,6 @@ class MarketState extends Equatable {
         failure,
         status,
         failure,
-        allBundles,
         unpurchasedBundles,
         trackCount,
         userTrackCount,
@@ -67,7 +63,6 @@ class MarketState extends Equatable {
   MarketState copyWith({
     MarketStatus? status,
     Failure? failure,
-    List<Bundle>? allBundles,
     List<Bundle>? unpurchasedBundles,
     int? trackCount,
     int? userTrackCount,
@@ -78,7 +73,6 @@ class MarketState extends Equatable {
     return MarketState(
       status: status ?? this.status,
       failure: failure ?? this.failure,
-      allBundles: allBundles ?? this.allBundles,
       unpurchasedBundles: unpurchasedBundles ?? this.unpurchasedBundles,
       trackCount: trackCount ?? this.trackCount,
       userTrackCount: userTrackCount ?? this.userTrackCount,

--- a/lib/models/bundle_model.dart
+++ b/lib/models/bundle_model.dart
@@ -21,7 +21,6 @@ class Bundle extends Equatable {
   final int? sortOrder;
   final bool? available;
   final bool? isNew;
-  bool? isOwned;
   final String? priceString;
   int? count;
   final String? category;
@@ -44,7 +43,6 @@ class Bundle extends Equatable {
     this.sortOrder,
     this.available,
     this.isNew,
-    this.isOwned,
     this.priceString,
     this.count,
     this.category,
@@ -69,7 +67,6 @@ class Bundle extends Equatable {
         sortOrder,
         available,
         isNew,
-        isOwned,
         priceString,
         count,
         category,
@@ -91,7 +88,6 @@ class Bundle extends Equatable {
       years: data['years'] as String?, //?? '2000-test',
       available: data['available'] as bool?, // ?? false,
       isNew: data['new'] as bool?, // ?? false,
-      isOwned: data['purchased'] as bool?, //?? false,
       priceString: data['price_string'] as String?, //?? '0',
       count: data['count'] as int?, // ?? 0,
       category: data['category'] as String?,
@@ -116,7 +112,6 @@ class Bundle extends Equatable {
   //     years: data['years'] as String, //?? '2000-test',
   //     available: data['available'] as bool, // ?? false,
   //     isNew: data['new'] as bool, // ?? false,
-  //     isOwned: data['purchased'] as bool, //?? false,
   //     priceString: data['price_string'] as String, //?? '0',
   //     count: data['count'] as int, // ?? 0,
   //     category: data['category'] as String,
@@ -143,7 +138,6 @@ class Bundle extends Equatable {
       years: data['years'] as String? ?? '2000-test',
       available: data['available'] as bool? ?? false,
       isNew: data['new'] as bool? ?? false,
-      isOwned: data['purchased'] as bool? ?? false,
       priceString: data['price_string'] as String? ?? '0',
       count: data['count'] as int? ?? 0,
       category: data['category'] as String? ?? '',
@@ -170,7 +164,6 @@ class Bundle extends Equatable {
   //     // sortOrder: (data['sortOrder'] ?? 100),
   //     available: (data['available'] ?? false),
   //     isNew: (data['new'] ?? false),
-  //     isOwned: (data['purchased'] ?? false),
   //     priceString: (data['price_string'] ?? 0),
   //     count: (data['count'] ?? 0),
   //     category: (data['category'] ?? ''),
@@ -191,7 +184,6 @@ class Bundle extends Equatable {
       'years': years,
       'available': available,
       'new': isNew,
-      'purchased': isOwned,
       'price_string': priceString,
       'count': count,
       'category': category,
@@ -216,7 +208,6 @@ class Bundle extends Equatable {
     int? sortOrder,
     bool? available,
     bool? isNew,
-    bool? isOwned,
     String? priceString,
     int? count,
     String? category,
@@ -239,7 +230,6 @@ class Bundle extends Equatable {
       sortOrder: sortOrder ?? this.sortOrder,
       available: available ?? this.available,
       isNew: isNew ?? this.isNew,
-      isOwned: isOwned ?? this.isOwned,
       priceString: priceString ?? this.priceString,
       count: count ?? this.count,
       category: category ?? this.category,

--- a/lib/repositories/user/base_user_repository.dart
+++ b/lib/repositories/user/base_user_repository.dart
@@ -7,8 +7,6 @@ abstract class BaseUserRepository {
   void connectDiscord({required User user, required String discordId});
   Future<List<User>> getAllArtists();
   Future<User> getUserWithId({required String userId});
-  Future<List<Bundle>> getBundlesApi();
-  Future<List<Bundle>> getUserBundlesApi({required List<String> bundleIds});
   Future<void> updateUser({required User user});
   Future<List<User>> searchUsers({required String query});
   Future<List<User>> fetchUsersApi();

--- a/lib/repositories/user/user_repository.dart
+++ b/lib/repositories/user/user_repository.dart
@@ -218,50 +218,6 @@ class UserRepository extends BaseUserRepository {
   // }
 
   @override
-  Future<List<Bundle>> getBundlesApi() async {
-    final uri = Uri.parse(Core.app.bundlesAPIUrl);
-    logger.i('getBundlesApi: $uri');
-    try {
-      final response = await http.get(
-        uri,
-        headers: {
-          'TOKEN': Core.app.serverToken,
-          'userId': '8',
-        },
-      );
-      if (response.body.isEmpty) {
-        logger.e('user_repo getBundlesApi error: response.body.isEmpty');
-        return [];
-      }
-
-      // Notice how you have to call body from the response if you are using http to retrieve json
-      final body = json.decode(response.body) as Map<String, dynamic>;
-      if (body.containsKey('error')) {
-        logger.e('user_repo getBundlesApi error: ${body['message']}');
-        return [];
-      }
-      final data = body['bundles'] as List<dynamic>;
-      final lastUpdated = body['last_updated'].toString();
-      logger.i('Bundles last updated at: $lastUpdated');
-      final bundles = data.map(Bundle.fromJson).toList();
-      return bundles;
-    } catch (err) {
-      logger.e('user_repo getBundlesApi error: $err');
-      return [];
-    }
-  }
-
-  @override
-  Future<List<Bundle>> getUserBundlesApi({
-    required List<String> bundleIds,
-  }) async {
-    final allBundles = await getBundlesApi();
-    final userBundles =
-        allBundles.where((i) => bundleIds.contains(i.id.toString())).toList();
-    return userBundles;
-  }
-
-  @override
   Future<void> updateUser({required User? user}) async {
     await _firebaseFirestore
         .collection(Paths.users)

--- a/lib/screens/artist/artist_screen.dart
+++ b/lib/screens/artist/artist_screen.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'package:audioplayers/audioplayers.dart' as ap;
 import 'package:boxify/app_core.dart';
+import 'package:boxify/services/bundles_manager.dart';
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
@@ -130,7 +131,7 @@ class _ArtistScreenState extends State<ArtistScreen>
                 Navigator.of(dialogContext).pop();
               },
             ),
-            if (kIsWeb && !bundle.isOwned! == false)
+            if (kIsWeb && !BundleManager().isOwned(bundle.id))
               ElevatedButton(
                 style: ElevatedButton.styleFrom(
                   backgroundColor: Core.appColor.primary,
@@ -203,10 +204,12 @@ class _ArtistScreenState extends State<ArtistScreen>
       context: context,
       builder: (_) {
         final profileState = context.read<ArtistBloc>().state;
-        final allBundles = profileState.allBundles;
         final user = profileState.user;
         final username = user.username;
         var updated = false;
+
+        final allBundles = BundleManager().bundlesList;
+
         return AlertDialog(
           title: DialogTitle(itemName: 'Packs', username: username),
           content: Align(
@@ -844,8 +847,8 @@ class _ArtistScreenState extends State<ArtistScreen>
                             isLargeScreen
                                 ? PlaylistsForLargeArtist(
                                     sectionHeight: getLargeSectionHeight(
-                                        state.userPlaylists.length, crossAxisCount),
-                                        
+                                        state.userPlaylists.length,
+                                        crossAxisCount),
                                     playlists: userPlaylists,
                                   )
                                 : SmallMediaSection(

--- a/lib/screens/market/widgets/bundle_card_for_market.dart
+++ b/lib/screens/market/widgets/bundle_card_for_market.dart
@@ -1,5 +1,6 @@
 import 'package:audioplayers/audioplayers.dart' as ap;
 import 'package:boxify/app_core.dart';
+import 'package:boxify/services/bundles_manager.dart';
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -89,7 +90,7 @@ class _BundleCardForMarketScreenState extends State<BundleCardForMarketScreen> {
       if (isSuccess) {
         final email = authBloc.state.user!.email!;
         marketBloc.add(
-            PurchaseBundle(id: widget.bundle.id, user: userBloc.state.user));
+            PurchaseBundle(id: widget.bundle.id!, user: userBloc.state.user));
         // final message =
         //     "You now have access to all the tracks in '${widget.bundle.title!}'. Please check $email for a download link (check spam, if necessary). Email assistant@riverscuomo.com with any problems.";
         // showMySnack(context, message: message);
@@ -193,7 +194,7 @@ class _BundleCardForMarketScreenState extends State<BundleCardForMarketScreen> {
               Navigator.of(dialogContext).pop(); // Corrected this line
             },
           ),
-          if (bundle.isOwned == false)
+          if (BundleManager().isOwned(bundle.id))
             ElevatedButton(
               style: ElevatedButton.styleFrom(
                 backgroundColor: Colors.blueAccent,
@@ -249,7 +250,7 @@ class _BundleCardForMarketScreenState extends State<BundleCardForMarketScreen> {
                 color: Colors.grey[300],
               ),
             ),
-            if (widget.bundle.isOwned == true)
+            if (BundleManager().isOwned(widget.bundle.id))
               Padding(
                 padding: const EdgeInsets.all(8),
                 child: Text(

--- a/lib/screens/settings/buttons/discord.dart
+++ b/lib/screens/settings/buttons/discord.dart
@@ -22,7 +22,7 @@ class DiscordFormField extends StatelessWidget {
         onFieldSubmitted: (String value) {
           var discordId = value;
 
-          if (value!.length < 10) {
+          if (value.length < 10) {
             showMySnack(
               context,
               color: Core.appColor.discordColor,
@@ -49,10 +49,8 @@ class DiscordFormField extends StatelessWidget {
           hintMaxLines: 3,
           border: const OutlineInputBorder(),
           focusedBorder: OutlineInputBorder(
-            borderSide: BorderSide(
-              color: Core.appColor.focusedBorder,
-              width: 2.0
-            ),
+            borderSide:
+                BorderSide(color: Core.appColor.focusedBorder, width: 2.0),
           ),
           hintText: user.discordId.isNotEmpty
               ? user.discordId

--- a/lib/services/bundles_manager.dart
+++ b/lib/services/bundles_manager.dart
@@ -1,6 +1,7 @@
 import 'package:boxify/app_core.dart';
 
-/// Stores and manages the list of bundles available in the app.
+/// Stores and manages the list of bundles available in the app,
+/// and stores which bundles the user has purchased.
 class BundleManager {
   // Singleton instance (for static access across the app)
   static final BundleManager _instance = BundleManager._internal();
@@ -8,6 +9,9 @@ class BundleManager {
   BundleManager._internal();
 
   final Map<String, Bundle> _bundles = {};
+
+  // List of owned bundle IDs
+  final List<String> _ownedBundleIds = [];
 
   // Public accessor for bundles
   Map<String, Bundle> get bundles => Map.unmodifiable(_bundles);
@@ -31,5 +35,18 @@ class BundleManager {
       return _bundles[id];
     }
     return null;
+  }
+
+  // Is the bundle owned by the user?
+  bool isOwned(String? id) {
+    if (id == null) return false;
+    return _ownedBundleIds.contains(id);
+  }
+
+  // Set owned bundle IDs
+  void setOwnedBundleIds(List<String> ids) {
+    logger.i('setOwnedBundleIds: $ids');
+    _ownedBundleIds.clear();
+    _ownedBundleIds.addAll(ids);
   }
 }


### PR DESCRIPTION
The primary goal of this PR is to implement the new `BundleManager` introduced in #140 everywhere in the app.

## Changes:
By using the new bundles manager, profile load time was significantly shortened, since it used to make 2 API calls every time the profile was opened:

| Before | After |
|--------|--------|
| ![boxify-profile-before](https://github.com/user-attachments/assets/79f39998-894f-426f-a47f-bbcb8b1001d9) |![boxify-profile-after_2_](https://github.com/user-attachments/assets/1b3acda9-f14f-4da1-8e55-c819c6e94d22) |

Loading time has been reduced from a few seconds to less than half a second.

## Refactoring with the new BundleManager:
I've tried to implement the new centralized and efficient `BundleManager` everywhere, and subsequently removed redundant bundle lists from the `ArtistState`, `MarketState` and `SettingsState`.

Additionally, I've removed the `isOwned` property from the track model, ownership checks are now done directly in the `BundleManager` using the new `isOwned(<bundleId>)` method.

```dart
BundleManager().isOwned(bundle.id)
```