### PR TITLE
Lazy-load user data (shorten app startup time)

### DIFF
--- a/lib/blocs/playlist/playlist_bloc.dart
+++ b/lib/blocs/playlist/playlist_bloc.dart
@@ -151,8 +151,7 @@ class PlaylistBloc extends Bloc<PlaylistEvent, PlaylistState> {
     List<String>? roles;
 
     if (Core.app.type == AppType.basic) {
-      final user = await _userRepository.getUserWithId(
-          userId: _authBloc.state.user!.uid);
+      final user = await _userRepository.getSelfUser(_authBloc.state.user!.uid);
       roles = user.roles;
     }
 
@@ -298,8 +297,7 @@ class PlaylistBloc extends Bloc<PlaylistEvent, PlaylistState> {
         _playlistHelper.getRecommendedPlaylists(event.user, state.allPlaylists);
 
     if (Core.app.type == AppType.basic) {
-      final user = await _userRepository.getUserWithId(
-          userId: _authBloc.state.user!.uid);
+      final user = await _userRepository.getSelfUser(_authBloc.state.user!.uid);
       final roles = user.roles;
       followedPlaylists = filterPlaylistsByRole(roles, followedPlaylists);
       recommendedPlaylists = filterPlaylistsByRole(roles, recommendedPlaylists);

--- a/lib/blocs/playlist/playlist_bloc.dart
+++ b/lib/blocs/playlist/playlist_bloc.dart
@@ -142,16 +142,20 @@ class PlaylistBloc extends Bloc<PlaylistEvent, PlaylistState> {
     logger.i('_onLoadAllPlaylists');
     emit(state.copyWith(status: PlaylistStatus.playlistsLoading));
 
+    final userId = _authBloc.state.user!.uid;
+
     if (event.clearCache) {
       logger.i('clearing playlists cache');
-      await _cacheHelper.clearSpecific(
-          CacheHelper.keyForPlaylists(_authBloc.state.user!.uid));
+      await _cacheHelper.clearSpecific(CacheHelper.keyForPlaylists(userId));
     }
 
     List<String>? roles;
 
     if (Core.app.type == AppType.basic) {
-      final user = await _userRepository.getSelfUser(_authBloc.state.user!.uid);
+      // Get the roles of the user from the cache
+      User? user = await _userRepository.getUserFromCache(userId);
+      // User not in cache: get from firestore (should not happen, but just in case)
+      user ??= await _userRepository.getSelfUser(userId);
       roles = user.roles;
     }
 
@@ -280,6 +284,8 @@ class PlaylistBloc extends Bloc<PlaylistEvent, PlaylistState> {
     List<Playlist> followedPlaylists;
     List<Playlist> recommendedPlaylists;
 
+    final userId = _authBloc.state.user!.uid;
+
     final result =
         _playlistHelper.getFollowedPlaylists(event.user, state.allPlaylists);
 
@@ -297,8 +303,12 @@ class PlaylistBloc extends Bloc<PlaylistEvent, PlaylistState> {
         _playlistHelper.getRecommendedPlaylists(event.user, state.allPlaylists);
 
     if (Core.app.type == AppType.basic) {
-      final user = await _userRepository.getSelfUser(_authBloc.state.user!.uid);
+      // Get the roles of the user from the cache
+      User? user = await _userRepository.getUserFromCache(userId);
+      // User not in cache: get from firestore (should not happen, but just in case)
+      user ??= await _userRepository.getSelfUser(userId);
       final roles = user.roles;
+
       followedPlaylists = filterPlaylistsByRole(roles, followedPlaylists);
       recommendedPlaylists = filterPlaylistsByRole(roles, recommendedPlaylists);
     }

--- a/lib/blocs/user/user_bloc.dart
+++ b/lib/blocs/user/user_bloc.dart
@@ -136,6 +136,7 @@ class UserBloc extends Bloc<UserEvent, UserState> {
     logger.i('_loadAdvancedUser');
     emit(state.copyWith(status: UserStatus.loading));
 
+    final startTime = DateTime.now();
     final userId = _authBloc.state.user!.uid;
 
     if (event.clearCache == true) {
@@ -145,7 +146,25 @@ class UserBloc extends Bloc<UserEvent, UserState> {
     }
 
     try {
-      final user = await _userRepository.getUserWithId(userId: userId);
+      // Is there a cached user available?
+      // We use the cached user first since it's much faster to load
+      // then we can load the updated user from the server
+      User? user = await _userRepository.getUserFromCache(userId);
+      final isSelfCached = user != null;
+
+      // User couldn't be found in the cache, so we need to fetch it right away
+      if (!isSelfCached) {
+        user = await _userRepository.getSelfUser(userId);
+      } else {
+        // Asynchronously fetch the user from the server
+        _userRepository.getSelfUser(userId).then((fetchedUser) {
+          // Update state with the fetched user
+          emit(state.copyWith(user: fetchedUser));
+        }).catchError((error) {
+          logger.e('Error fetching user from server: $error');
+        });
+      }
+
       final ratings =
           await _trackRepository.getUserRatings(userId, _firebaseFirestore);
       final allArtists = await _userRepository.getAllArtists();
@@ -186,6 +205,8 @@ class UserBloc extends Bloc<UserEvent, UserState> {
         ),
       ));
     }
+
+    logRunTime(startTime, 'UserBloc: _loadAdvancedUser');
   }
 
   Future<void> _onBundlePurchaseSuccess(
@@ -307,85 +328,5 @@ class UserBloc extends Bloc<UserEvent, UserState> {
       // ... Update state with error information as needed
       return false;
     }
-  }
-
-  /// Loads from cache or if cache is null, fetches data from the rc.com server
-  /// or directly from Firestore.
-  /// And saves it to the cache.
-  /// User, tracks, bundles, playlists, ratings, and artists.
-  Future<List<dynamic>> loadData(
-    FirebaseFirestore firebaseFirestore,
-    String userId, {
-    bool forceFetch = false,
-    DateTime? serverRatingsUpdated,
-  }) async {
-    logger.i('loadData for $userId with forceFetch = $forceFetch');
-    User? cachedUser;
-    // List<Track>? cachedTracks;
-    // List<Bundle>? bundles;
-    // List<Playlist>? playlists;
-    List<Rating>? ratings;
-    List<User>? artists;
-
-    // forceFetch = true;
-    // _cacheHelper.clearAll();
-    // _cacheHelper.clearSpecific(CacheHelper.KEY_USER);
-
-    // final serverTimestamps =
-    //     await _metaDataRepository.getServerTimestamps(userId);
-
-    // TODO
-    // Fetch data from cache only if forceFetch is false
-    if (!forceFetch) {
-      // cachedUser = await _cacheHelper.getUser(serverUserUpdated!);
-      // cachedTracks = await _cacheHelper.getTracks(serverTimestamps['tracks']!);
-      // bundles = await _cacheHelper.getBundles();
-      // // playlists = await _cacheHelper.fetchPlaylists(user!.id);
-      ratings = await _cacheHelper.getRatings(userId);
-      // artists = await _cacheHelper.getArtists(serverUsersUpdated!);
-
-      // logger.i('loadData: got cache');
-    }
-
-    // For each data object (user, tracks, bundles, etc.), fetch it if it's null
-    // (not in the cache or the cache is expired), otherwise, use the existing cached
-    // value, and add it to the 'responses' list
-    final responses = await Future.wait([
-      // User
-      _userRepository.getUserWithId(userId: userId),
-
-      if (ratings == null)
-        _trackRepository.getUserRatings(userId, firebaseFirestore)
-      else
-        Future.value(ratings),
-      _userRepository.getAllArtists(),
-    ]);
-    logger.i('loadData: got responses');
-
-    final User user;
-    // final List<Track> tracks;
-
-    user = responses[0] as User;
-    // tracks = responses[1] ;
-
-    if (cachedUser == null) {
-      logger.i('no cachedUser!');
-
-      // Save the fetched data to cache if it was not available
-      await _cacheHelper.saveUser(user);
-    } else {
-      logger.i('there is a cachedUser!');
-    }
-    logger.i('user.username: ${user.username}');
-
-    if (ratings == null) {
-      ratings = responses[1] as List<Rating>;
-      await _cacheHelper.saveRatings(ratings, _authBloc.state.user!.uid);
-    }
-    artists = responses[2] as List<User>;
-    await _cacheHelper.saveArtists(artists);
-    logger.i('_cacheHelper.saveArtists(artists)');
-
-    return [user, ratings, artists];
   }
 }

--- a/lib/blocs/user/user_bloc.dart
+++ b/lib/blocs/user/user_bloc.dart
@@ -118,6 +118,11 @@ class UserBloc extends Bloc<UserEvent, UserState> {
       if (isSelfCached) {
         user = await _userRepository.getSelfUser(userId);
         emit(state.copyWith(user: user));
+
+        // Check if the user roles have changed between cached and server user
+        if (event.onRolesUpdated != null && user.roles != state.user.roles) {
+          event.onRolesUpdated!();
+        }
       }
     } on NoConnectionException catch (e) {
       logger.e('NoConnectionException: $e');

--- a/lib/blocs/user/user_event.dart
+++ b/lib/blocs/user/user_event.dart
@@ -65,8 +65,12 @@ class LoadUser extends UserEvent {
   final bool clearCache;
   final DateTime serverRatingsUpdated;
 
+  /// Callback to be called when the user roles are updated (basic app only)
+  final VoidCallback? onRolesUpdated;
+
   const LoadUser({
     this.clearCache = false,
+    this.onRolesUpdated,
     required this.serverRatingsUpdated,
   });
 

--- a/lib/my_app.dart
+++ b/lib/my_app.dart
@@ -394,8 +394,13 @@ class MyApp extends StatelessWidget {
                   LoadUser(
                       clearCache: marketBloc.state.status ==
                           MarketStatus.bundlePurchased,
-                      serverRatingsUpdated:
-                          state.serverTimestamps['ratings2']!),
+                      serverRatingsUpdated: state.serverTimestamps['ratings2']!,
+                      onRolesUpdated: () {
+                        // User roles have changed, reload all playlists
+                        final playlistBloc = context.read<PlaylistBloc>();
+                        playlistBloc.add(
+                            LoadAllPlaylists(userId: userBloc.state.user.id));
+                      }),
                 );
               }
             }

--- a/lib/repositories/metadata/metadata_repository.dart
+++ b/lib/repositories/metadata/metadata_repository.dart
@@ -14,6 +14,11 @@ class DataFetchException implements Exception {
   DataFetchException(this.message);
 }
 
+class CacheException implements Exception {
+  final String message;
+  CacheException(this.message);
+}
+
 class MetaDataRepository extends BaseMetaDataRepository {
   MetaDataRepository({
     FirebaseFirestore? firebaseFirestore,

--- a/lib/repositories/user/base_user_repository.dart
+++ b/lib/repositories/user/base_user_repository.dart
@@ -7,6 +7,7 @@ abstract class BaseUserRepository {
   void connectDiscord({required User user, required String discordId});
   Future<List<User>> getAllArtists();
   Future<User> getUserWithId({required String userId});
+  Future<User> getSelfUser(String userId, {bool prioritizeCache = false});
   Future<void> updateUser({required User user});
   Future<List<User>> searchUsers({required String query});
   Future<List<User>> fetchUsersApi();

--- a/lib/repositories/user/base_user_repository.dart
+++ b/lib/repositories/user/base_user_repository.dart
@@ -7,7 +7,7 @@ abstract class BaseUserRepository {
   void connectDiscord({required User user, required String discordId});
   Future<List<User>> getAllArtists();
   Future<User> getUserWithId({required String userId});
-  Future<User> getSelfUser(String userId, {bool prioritizeCache = false});
+  Future<User> getSelfUser(String userId);
   Future<void> updateUser({required User user});
   Future<List<User>> searchUsers({required String query});
   Future<List<User>> fetchUsersApi();

--- a/lib/repositories/user/user_repository.dart
+++ b/lib/repositories/user/user_repository.dart
@@ -92,22 +92,58 @@ class UserRepository extends BaseUserRepository {
     // logger.i(user.banned);
   }
 
-  // /// Fetches a user with the given [userId] from the Firestore collection.
+  /// Fetches a user with the given [userId] from the Firestore collection
+  /// or returns a cached user if offline.
+  /// When fetching the currently logged-in user, it is better to use the [getSelfUser] method.
   @override
   Future<User> getUserWithId({required String userId}) async {
     logger.i('getUserWithId: $userId');
 
     if (ConnectivityManager.instance.currentStatus == ConnectivityResult.none) {
       // Offline, get user from cache
-      final cachedUser = await _cacheHelper.getUser(userId);
-      if (cachedUser != null) {
-        logger.i('Returning cached user data');
-        return cachedUser;
-      } else {
-        logger.e('No internet connection and no cached user data.');
-        throw NoConnectionException(
-            'No internet connection and no cached user data.');
+      return getUserFromCacheWithException(userId);
+    } else {
+      // Online, fetch from Firestore
+      try {
+        final userDocRef =
+            _firebaseFirestore.collection(Paths.users).doc(userId);
+        final doc = await userDocRef.get();
+
+        if (doc.exists) {
+          // User exists
+          final user = User.fromDocument(doc);
+          return user;
+        } else {
+          logger.i('No user doc found, returning empty user');
+          final user = User.empty.copyWith(id: userId);
+          return user;
+        }
+      } catch (e) {
+        logger.e('Error fetching user data: $e');
+        return getUserFromCacheWithException(userId);
       }
+    }
+  }
+
+  /// Fetches the currently logged-in user from Firestore.
+  /// If offline, it attempts to get the user from the cache.
+  /// If the user is not found in the cache, it returns an empty user.
+  ///
+  /// This method will update the user's last seen timestamp in Firestore
+  /// and cache the user data, unlike the [getUserWithId] method.
+  ///
+  /// If [prioritizeCache] is true, cache data will be returned if available,
+  /// otherwise will fetch from Firestore.
+  @override
+  Future<User> getSelfUser(
+    String userId, {
+    bool prioritizeCache = false,
+  }) async {
+    logger.i('getSelfUser: $userId');
+
+    if (ConnectivityManager.instance.currentStatus == ConnectivityResult.none) {
+      // Offline, get user from cache
+      return getUserFromCacheWithException(userId);
     } else {
       // Online, fetch from Firestore
       try {
@@ -131,91 +167,27 @@ class UserRepository extends BaseUserRepository {
         }
       } catch (e) {
         logger.e('Error fetching user data: $e');
-        // Attempt to get cached user
-        final cachedUser = await _cacheHelper.getUser(userId);
-        if (cachedUser != null) {
-          logger.i('Returning cached user data after exception');
-          return cachedUser;
-        } else {
-          throw DataFetchException(
-              'Failed to fetch user data and no cached data available.');
-        }
+        return getUserFromCacheWithException(userId);
       }
     }
   }
 
-  // /// Updates the user's last seen timestamp if they exist.
-  // /// Returns an empty user if they don't exist.
-  // @override
-  // Future<User> getUserWithId({required String userId}) async {
-  //   logger.i('getUserWithId: $userId');
+  /// Returns user from cache, or raises an exception if not found.
+  Future<User> getUserFromCacheWithException(String userId) async {
+    final cachedUser = await getUserFromCache(userId);
+    if (cachedUser != null) {
+      logger.i('Returning cached user data');
+      return cachedUser;
+    } else {
+      logger.e('No cached user data available.');
+      throw CacheException('No cached user data available.');
+    }
+  }
 
-  //   // Check connectivity
-  //   if (ConnectivityManager.instance.currentStatus == ConnectivityResult.none) {
-  //     // Offline, attempt to get user from cache
-  //     final cachedUser = await _cacheHelper.getUser(userId);
-  //     if (cachedUser != null) {
-  //       logger.i('Returning cached user data');
-  //       return cachedUser;
-  //     } else {
-  //       // No cached data, return a default or empty user
-  //       logger.e('No internet and no cached user data available.');
-  //       return User.empty.copyWith(id: userId);
-  //     }
-  //   } else {
-  //     // Online, fetch from Firestore
-  //     try {
-  //       final userDocRef =
-  //           _firebaseFirestore.collection(Paths.users).doc(userId);
-  //       final doc = await userDocRef.get();
-
-  //       if (doc.exists) {
-  //         logger.i('User exists, updating lastSeen timestamp');
-  //         await userDocRef.update({'lastSeen': DateTime.now()});
-  //         final user = User.fromDocument(doc);
-
-  //         // Save user to cache
-  //         await _cacheHelper.saveUser(user);
-
-  //         return user;
-  //       } else {
-  //         logger.i('No user doc found, must be anonymous');
-  //         final user = User.empty.copyWith(id: userId);
-  //         return user;
-  //       }
-  //     } catch (e) {
-  //       logger.e('Error fetching user data: $e');
-  //       // Attempt to get cached user
-  //       final cachedUser = await _cacheHelper.getUser(userId);
-  //       if (cachedUser != null) {
-  //         logger.i('Returning cached user data after exception');
-  //         return cachedUser;
-  //       } else {
-  //         return User.empty.copyWith(id: userId);
-  //       }
-  //     }
-  //   }
-  // }
-
-  // @override
-  // Future<User> getUserWithId({required String userId}) async {
-  //   logger.i('getUserWithId: $userId');
-  //   final userDocRef = _firebaseFirestore.collection(Paths.users).doc(userId);
-  //   final doc = await userDocRef.get();
-
-  //   // Check if the user document exists before updating the lastSeen timestamp.
-  //   if (doc.exists) {
-  //     logger.i('User exists, updating lastSeen timestamp');
-  //     await userDocRef.update({'lastSeen': DateTime.now()});
-  //     return User.fromDocument(doc);
-  //   } else {
-  //     logger.i('No user doc found, must be anonymous or Rivify');
-  //     final user = User.empty.copyWith(
-  //       id: userId,
-  //     );
-  //     return user;
-  //   }
-  // }
+  /// Returns a user from Firestore or cache. Returns null if not found.
+  Future<User?> getUserFromCache(String userId) async {
+    return _cacheHelper.getUser(userId);
+  }
 
   @override
   Future<void> updateUser({required User? user}) async {
@@ -329,14 +301,7 @@ class UserRepository extends BaseUserRepository {
 
     if (ConnectivityManager.instance.currentStatus == ConnectivityResult.none) {
       // Offline, get artists from cache
-      final cachedArtists = await _cacheHelper.getArtists();
-      if (cachedArtists != null) {
-        logger.i('Returning cached artists');
-        return cachedArtists;
-      } else {
-        logger.e('No internet connection and no cached artists available.');
-        return [];
-      }
+      return getArtistsFromCache();
     } else {
       // Online, fetch from Firestore
       try {
@@ -355,14 +320,20 @@ class UserRepository extends BaseUserRepository {
       } catch (e) {
         logger.e('Error fetching artists: $e');
         // Return cached artists if available
-        final cachedArtists = await _cacheHelper.getArtists();
-        if (cachedArtists != null) {
-          logger.i('Returning cached artists after exception');
-          return cachedArtists;
-        } else {
-          return [];
-        }
+        return getArtistsFromCache();
       }
+    }
+  }
+
+  /// Returns artists from cache
+  Future<List<User>> getArtistsFromCache() async {
+    final cachedArtists = await _cacheHelper.getArtists();
+    if (cachedArtists != null) {
+      logger.i('Returning cached artists');
+      return cachedArtists;
+    } else {
+      logger.e('No cached artists available.');
+      return [];
     }
   }
 

--- a/lib/repositories/user/user_repository.dart
+++ b/lib/repositories/user/user_repository.dart
@@ -131,14 +131,8 @@ class UserRepository extends BaseUserRepository {
   ///
   /// This method will update the user's last seen timestamp in Firestore
   /// and cache the user data, unlike the [getUserWithId] method.
-  ///
-  /// If [prioritizeCache] is true, cache data will be returned if available,
-  /// otherwise will fetch from Firestore.
   @override
-  Future<User> getSelfUser(
-    String userId, {
-    bool prioritizeCache = false,
-  }) async {
+  Future<User> getSelfUser(String userId) async {
     logger.i('getSelfUser: $userId');
 
     if (ConnectivityManager.instance.currentStatus == ConnectivityResult.none) {

--- a/lib/screens/login/login_screen.dart
+++ b/lib/screens/login/login_screen.dart
@@ -115,9 +115,8 @@ class LoginScreen extends StatelessWidget {
       logger.i(
         'login: authUser.emailVerified so fetching user record to check their username',
       );
-      final user = await context
-          .read<UserRepository>()
-          .getUserWithId(userId: authUser.uid);
+      final user =
+          await context.read<UserRepository>().getSelfUser(authUser.uid);
       // logger.i('login: user fetched from firestore = $user');
 
       /// User still does not have a username or has the username 'Lurker'

--- a/lib/screens/playlist/base_playlist_screen.dart
+++ b/lib/screens/playlist/base_playlist_screen.dart
@@ -71,7 +71,7 @@ class _BasePlaylistScreenState extends State<BasePlaylistScreen>
         }
       } catch (e) {
         if (widget.playlistId != context.read<AuthBloc>().state.user!.uid) {
-          logger.e('Error finding playlist with id: $widget.playlistId  $e');
+          logger.e('Error finding playlist with id: ${widget.playlistId}  $e');
         }
       }
     }


### PR DESCRIPTION
I didn't forget about this haha. just took a short break. anyways, here's phase 3 of #104:


## Lazy load user data
User data is now loaded **asynchronously** , and the app will instead use the **cached user** while waiting for the Firestore data to be fetched.

**Before:**
![image](https://github.com/user-attachments/assets/e732e454-7383-4e9e-80c6-b193b57fff1d)

**After:**
![image](https://github.com/user-attachments/assets/e0e48d55-b3d1-4ac8-b107-021b3bbc945c)

This change makes the initial startup time **>0.4s** faster on average for logged-in users!

## New getSelfUser method

`UserRepository`'s `getUserWithId` method used to **save the result** to cache, and update the `lastSeen` field. So when visiting anyone's profile, the user would cache all of their profile data to cache and update their `lastSeen` value incorrectly - taking up a lot of memory space for unused data.

That's why I added a new `getSelfUser` method, that will update the local cache & the `lastSeen` value, while the `getUserWithId` now only fetches from Firestore without doing any additional action.

```dart
await _userRepository.getSelfUser(userId);
```

## Basic App
I haven't implemented these changes to the Basic App, since I don't want to break anything. But those changes should work just fine if they were to be added.

---

I've also done some cleaning up and refactoring - I hope that's fine.
**Let me know if there are any issue or question with these changes!**